### PR TITLE
Handle mismatched edited text lines gracefully

### DIFF
--- a/tests/test_edited_text.py
+++ b/tests/test_edited_text.py
@@ -8,11 +8,18 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core import pipeline
 
 
-def test_apply_edited_text_wrong_line_count():
+def test_apply_edited_text_extra_lines_ignored():
     phrases = [(0.0, 1.0, "a"), (1.0, 2.0, "b")]
-    edited = "[[#1]] aa\n[[#2]] bb\n[[#3]] cc"
-    with pytest.raises(ValueError):
-        pipeline.apply_edited_text(phrases, edited)
+    edited = "[[#1]] aa\n[[#2]] bb\n[[#3]] cc"  # third line should be ignored
+    res = pipeline.apply_edited_text(phrases, edited)
+    assert res == [(0.0, 1.0, "aa"), (1.0, 2.0, "bb")]
+
+
+def test_apply_edited_text_missing_lines_preserve_original():
+    phrases = [(0.0, 1.0, "a"), (1.0, 2.0, "b"), (2.0, 3.0, "c")]
+    edited = "[[#1]] aa\n[[#2]] bb"  # third phrase remains 'c'
+    res = pipeline.apply_edited_text(phrases, edited)
+    assert res == [(0.0, 1.0, "aa"), (1.0, 2.0, "bb"), (2.0, 3.0, "c")]
 
 
 def test_revoice_video_calls_setup_and_catches(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Allow `apply_edited_text` to handle mismatched line counts by zipping phrases with lines and ignoring extras while preserving missing lines' text
- Add tests covering extra and missing line scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af0926b8888324bdd09fda68be3f5d