### PR TITLE
Add Silero TTS engine and improve TTS selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ uv run python -m ui.main_window
 ---
 
 ## TTS-движки (офлайн/онлайн)
-**Офлайн (приоритет):** Silero, Coqui XTTS-v2, Dia, Kokoro, MARS5, Orpheus  
-**Онлайн/гибрид:** Hume, Gemini, OpenAI TTS, Minimax, Chatterbox, VibeVoice  
+**Офлайн (приоритет):** Silero, Coqui XTTS-v2, Dia, Kokoro, MARS5, Orpheus
+**Онлайн/гибрид:** Hume, Gemini, OpenAI TTS, Minimax, Chatterbox, VibeVoice
 Сравнение: https://huggingface.co/spaces/TTS-AGI/TTS-Arena
+
+> Silero модели ищутся в папке `models/tts/silero/` (файл `.pt`).
 
 ---
 


### PR DESCRIPTION
## Summary
- add SileroTTS adapter loading local Silero models
- wire up `silero` engine in `synth_chunk` and pipeline
- document Silero model location

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af1342886c8324b40f409bc3bd4959