### PR TITLE
Correct SileroTTS model initialization

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -86,7 +86,11 @@ class SileroTTS:
                 raise FileNotFoundError(f"Silero model (.pt) not found in {self.model_dir}")
             model_path = pt_files[0]
             model = torch.package.PackageImporter(str(model_path)).load_pickle("tts_models", "model")
-            SileroTTS._model = model.to("cpu")
+            model.to("cpu")
+            model.eval()
+            SileroTTS._model = model
+        if SileroTTS._model is None:
+            raise RuntimeError("Failed to load Silero TTS model")
         return SileroTTS._model
 
     def tts(self, text: str, speaker: str, sr: int = 48000) -> np.ndarray:


### PR DESCRIPTION
## Summary
- ensure Silero TTS model is moved to CPU and stored correctly
- switch model to eval mode for inference
- raise a clear runtime error if model loading fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af1b3f801c83248eeac18c5b59d716