### PR TITLE
Handle missing eval in Silero TTS models

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -87,7 +87,8 @@ class SileroTTS:
             model_path = pt_files[0]
             model = torch.package.PackageImporter(str(model_path)).load_pickle("tts_models", "model")
             model.to("cpu")
-            model.eval()
+            if hasattr(model, "eval"):
+                model.eval()  # Some model versions do not provide eval()
             SileroTTS._model = model
         if SileroTTS._model is None:
             raise RuntimeError("Failed to load Silero TTS model")


### PR DESCRIPTION
## Summary
- Проверяем наличие метода `eval` у загруженной модели Silero
- Вызываем `model.eval()` только если метод доступен
- Добавлен комментарий, поясняющий отсутствие `eval` в некоторых версиях модели

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0137055a08324a6578d8b681a29e6