### PR TITLE
Исправление загрузки модели KokoroTTS

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -60,12 +60,12 @@ class KokoroTTS:
     def _ensure_model(self):
         if KokoroTTS._model is None:
             import kokoro
-            KokoroTTS._model = kokoro.load(self.model_dir)  # модель из локальной папки
+            KokoroTTS._model = kokoro.load_model(self.model_dir)  # model from the local directory
         return KokoroTTS._model
 
     def tts(self, text: str, speaker: str, sr: int = 48000) -> np.ndarray:
         model = self._ensure_model()
-        wav = model.tts(text or "", language="ru")  # укажем ru; при необходимости выберем en/ja
+        wav = model.tts(text or "", language="ru")  # use Russian; switch to en/ja if needed
         if not isinstance(wav, np.ndarray):
             wav = np.array(wav, dtype=np.float32)
         return wav.astype(np.float32)


### PR DESCRIPTION
## Summary
- Заменён вызов `kokoro.load` на `kokoro.load_model` в адаптере KokoroTTS
- Комментарии переведены на английский

## Testing
- `pytest -q`
- `python - <<'PY' ...` (мок для `kokoro`)


------
https://chatgpt.com/codex/tasks/task_b_68b01684d03c8324af749291eb14df6f