### PR TITLE
Добавлен запасной путь загрузки для KokoroTTS

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -59,9 +59,14 @@ class KokoroTTS:
 
     def _ensure_model(self):
         if KokoroTTS._model is None:
-            from kokoro import TTS  # new API for loading models
-            # Load model from the local directory using the updated Kokoro interface
-            KokoroTTS._model = TTS.load(self.model_dir)
+            try:
+                from kokoro import TTS  # prefer the new high-level API
+                # Load model via the new TTS API
+                KokoroTTS._model = TTS.load(self.model_dir)
+            except ImportError:
+                import kokoro  # fallback to the legacy module import
+                # Load model using the legacy interface
+                KokoroTTS._model = kokoro.load_model(self.model_dir)
         return KokoroTTS._model
 
     def tts(self, text: str, speaker: str, sr: int = 48000) -> np.ndarray:


### PR DESCRIPTION
## Summary
- добавлен блок try/except в KokoroTTS._ensure_model
- при наличии пакета `kokoro` используется `TTS.load`, иначе `kokoro.load_model`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b01a8d56c08324b2e4a03ce53ee505