### PR TITLE
Удалён ввод API ключа, добавлен диалог настроек

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -116,11 +116,6 @@ class MainWindow(QtWidgets.QMainWindow):
         grid.addWidget(self.lbl_voice, row, 2); grid.addWidget(self.cmb_voice, row, 3)
 
         row += 1
-        self.lbl_key = QtWidgets.QLabel("Yandex key:")
-        self.ed_key = QtWidgets.QLineEdit()  # Yandex Cloud API key
-        grid.addWidget(self.lbl_key, row, 0); grid.addWidget(self.ed_key, row, 1, 1, 3)
-
-        row += 1
         self.cmb_whisper = QtWidgets.QComboBox(); self.cmb_whisper.addItems(["large-v3","medium","small"])
         grid.addWidget(QtWidgets.QLabel("Whisper:"), row, 0); grid.addWidget(self.cmb_whisper, row, 1)
         self.ed_speed = QtWidgets.QLineEdit(str(self.speed_pct))
@@ -161,8 +156,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_reset = QtWidgets.QPushButton("Сброс")
         self.btn_open = QtWidgets.QPushButton("Открыть выход…")
         self.btn_help = QtWidgets.QPushButton("Помощь")
+        self.btn_settings = QtWidgets.QPushButton("Настройки")
         hb.addWidget(self.btn_rec); hb.addWidget(self.btn_edit); hb.addWidget(self.btn_run)
-        hb.addStretch(1); hb.addWidget(self.btn_help); hb.addWidget(self.btn_reset); hb.addWidget(self.btn_open)
+        hb.addStretch(1); hb.addWidget(self.btn_help); hb.addWidget(self.btn_settings); hb.addWidget(self.btn_reset); hb.addWidget(self.btn_open)
         layout.addLayout(hb)
 
         # Лог
@@ -176,6 +172,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.btn_reset.clicked.connect(self.reset_state)
         self.btn_open.clicked.connect(self.open_outdir)
         self.btn_help.clicked.connect(self.show_help)
+        self.btn_settings.clicked.connect(self.open_settings)
 
         # Горячие клавиши
         for key in ("Ctrl+O","Ctrl+S","Ctrl+E","Ctrl+Z","Ctrl+Y","Space","Ctrl+Enter"):
@@ -195,16 +192,13 @@ class MainWindow(QtWidgets.QMainWindow):
             self.lbl_voice.setText("Silero голос:")
             self.cmb_voice.setEditable(False)
             self.cmb_voice.addItems(SILERO_PRESETS)
-            self.lbl_key.hide(); self.ed_key.hide()  # Hide API key for non-Yandex engines
         elif engine == "yandex":
             self.lbl_voice.setText("Yandex голос:")
             self.cmb_voice.setEditable(False)
             self.cmb_voice.addItems(YANDEX_VOICES)
-            self.lbl_key.show(); self.ed_key.show()  # Show API key when using Yandex
         else:
             self.lbl_voice.setText("Голос:")
             self.cmb_voice.setEditable(True)
-            self.lbl_key.hide(); self.ed_key.hide()  # Hide API key for unknown engines
         self.cmb_voice.blockSignals(False)
 
     # ---------- Хелперы ----------
@@ -236,6 +230,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.log_print("Состояние сброшено. Готово к новому видео.")
 
     # ---------- Действия ----------
+    def open_settings(self):
+        """Open dialog to configure API keys."""
+        dlg = SettingsDialog(self, self.yandex_key, self.chatgpt_key)
+        if dlg.exec() == QtWidgets.QDialog.Accepted:
+            self.yandex_key, self.chatgpt_key = dlg.get_keys()
+
     def show_help(self):
         """Show instructions for connecting Yandex API."""
         # Build HTML text with clickable links
@@ -245,7 +245,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "2. В консоли создайте каталог и включите сервис SpeechKit.<br>"
             "3. Откройте меню 'Сервисные аккаунты' и создайте аккаунт.<br>"
             "4. На вкладке 'Ключи доступа' сформируйте API-ключ.<br>"
-            "5. Вставьте ключ в поле 'Yandex key' на главном экране.<br>"
+            "5. Вставьте ключ через кнопку 'Настройки' на главном экране.<br>"
             "Документация: "
             '<a href="https://cloud.yandex.ru/docs/speechkit/tts/quickstart">'
             "https://cloud.yandex.ru/docs/speechkit/tts/quickstart</a>"
@@ -313,7 +313,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 spell_latin=self.chk_latin.isChecked(), music_path=(self.ed_music.text().strip() or None),
                 music_db=float(self.ed_music_db.text() or "-18"), duck_ratio=float(self.ed_duck_ratio.text() or "8.0"),
                 duck_thresh=float(self.ed_duck_thresh.text() or "0.05"), tts_engine=engine,
-                yandex_key=self.ed_key.text().strip(), yandex_voice=voice,
+                yandex_key=self.yandex_key, yandex_voice=voice,
                 speed_jitter=float(self.ed_jitter.text() or "0.03")
             )
             self.log_print("Готово:", out); QtWidgets.QMessageBox.information(self,"Готово",f"Сохранено:\n{out}")


### PR DESCRIPTION
## Описание
- убраны элементы ввода API ключа из основного окна
- добавлена кнопка "Настройки" и диалог для редактирования ключей
- обновлена логика голосов и рендера под новый способ хранения ключа

## Тестирование
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b03f74e2e483248c613d4bedcf3691