### PR TITLE
Add configuration module for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ models/**
 !models/README.md
 bin/**
 sfx/**
+config.json
+config.key

--- a/ui/config.py
+++ b/ui/config.py
@@ -1,0 +1,61 @@
+"""Utility functions for loading and saving API keys configuration."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+try:
+    from cryptography.fernet import Fernet  # type: ignore
+    _HAS_FERNET = True
+except Exception:  # pragma: no cover - optional dependency
+    Fernet = None  # type: ignore
+    _HAS_FERNET = False
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_FILE = BASE_DIR / "config.json"
+KEY_FILE = BASE_DIR / "config.key"
+
+
+def _get_cipher() -> Fernet | None:
+    """Retrieve a Fernet cipher if available, otherwise return None."""
+    if not _HAS_FERNET:
+        return None
+    if not KEY_FILE.exists():
+        KEY_FILE.write_bytes(Fernet.generate_key())
+    key = KEY_FILE.read_bytes()
+    return Fernet(key)
+
+
+def load_config() -> tuple[str, str]:
+    """Load API keys from the config file, returning empty strings if absent."""
+    if not CONFIG_FILE.exists():
+        return "", ""
+    data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+    cipher = _get_cipher()
+    yandex_enc = data.get("yandex_key", "")
+    chatgpt_enc = data.get("chatgpt_key", "")
+    if cipher:
+        yandex_key = cipher.decrypt(yandex_enc.encode()).decode() if yandex_enc else ""
+        chatgpt_key = cipher.decrypt(chatgpt_enc.encode()).decode() if chatgpt_enc else ""
+    else:
+        yandex_key = base64.b64decode(yandex_enc).decode() if yandex_enc else ""
+        chatgpt_key = base64.b64decode(chatgpt_enc).decode() if chatgpt_enc else ""
+    return yandex_key, chatgpt_key
+
+
+def save_config(yandex_key: str, chatgpt_key: str) -> None:
+    """Encrypt and save API keys to the config file."""
+    cipher = _get_cipher()
+    if cipher:
+        data = {
+            "yandex_key": cipher.encrypt(yandex_key.encode()).decode() if yandex_key else "",
+            "chatgpt_key": cipher.encrypt(chatgpt_key.encode()).decode() if chatgpt_key else "",
+        }
+    else:
+        data = {
+            "yandex_key": base64.b64encode(yandex_key.encode()).decode() if yandex_key else "",
+            "chatgpt_key": base64.b64encode(chatgpt_key.encode()).decode() if chatgpt_key else "",
+        }
+    CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/ui/main.py
+++ b/ui/main.py
@@ -9,6 +9,7 @@ import os, subprocess, tempfile, traceback, logging, sys
 from datetime import datetime
 
 from .settings import SettingsDialog
+from .config import load_config, save_config
 
 # Version and log file
 APP_VER = "alpha3"
@@ -79,6 +80,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # API keys for external services
         self.yandex_key = ""
         self.chatgpt_key = ""
+        self.yandex_key, self.chatgpt_key = load_config()  # load stored keys
 
         log.info("UI start. Version=%s", APP_VER)
         self._build_ui()
@@ -243,10 +245,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
     # ---------- Действия ----------
     def open_settings(self):
-        """Open dialog to configure API keys."""
+        """Open dialog to configure API keys and persist them."""
         dlg = SettingsDialog(self, self.yandex_key, self.chatgpt_key)
         if dlg.exec() == QtWidgets.QDialog.Accepted:
             self.yandex_key, self.chatgpt_key = dlg.get_keys()
+            save_config(self.yandex_key, self.chatgpt_key)
 
     def show_help(self):
         """Show instructions for connecting Yandex API."""

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -8,10 +8,10 @@ class SettingsDialog(QtWidgets.QDialog):
         self.setWindowTitle("Настройки API")
 
         form = QtWidgets.QFormLayout(self)
-        # Yandex API key input
+        # Yandex API key input with preloaded default
         self.ed_yandex = QtWidgets.QLineEdit(yandex_key)
         form.addRow("Yandex key:", self.ed_yandex)
-        # ChatGPT API key input placeholder
+        # ChatGPT API key input with preloaded default
         self.ed_chatgpt = QtWidgets.QLineEdit(chatgpt_key)
         form.addRow("ChatGPT key:", self.ed_chatgpt)
 


### PR DESCRIPTION
## Summary
- add JSON config with optional encryption for API keys
- load and save API keys in main window and settings dialog
- ignore config files in version control

## Testing
- `pip install cryptography` (fails: Could not find a version)
- `pytest -q`
- `ruff check ui/config.py ui/main.py ui/settings.py` (fails: style errors)


------
https://chatgpt.com/codex/tasks/task_b_68b0644bdc0c83249a61bf02ea3947a3