### PR TITLE
Добавлена зависимость cryptography для шифрования

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-ffmpeg>=2.0",
     "pydantic>=2.7",
     "python-dateutil>=2.9",
+    "cryptography>=42.0.0", # encryption support
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- добавить cryptography>=42.0.0 для поддержки шифрования

## Testing
- `pip install -e .` (ошибка из-за отсутствия setuptools)
- `pip install -e . --no-build-isolation` (ошибка обнаружения пакетов)
- `python - <<'PY'\nimport importlib\ntry:\n    importlib.import_module('ui.config')\n    print('module ui.config imported')\nexcept Exception as e:\n    print('import failed:', e)\nPY` (No module named 'ui.config')
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b066645698832490cd60bc31e39d1a