### PR TITLE
chore: centralize Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,6 @@ dev = ["pytest>=8.0", "ruff>=0.5", "mypy>=1.10"]
 [tool.uv]
 # При желании можно зафиксировать индекс/кэши
 
-[tool.ruff]
-line-length = 100
-target-version = "py310"
-exclude = ["ui/"]
-
 [tool.mypy]
 python_version = "3.10"
 warn_unused_ignores = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,9 +1,8 @@
-
-target-version = "py310"
 line-length = 100
-
+target-version = "py310"
+exclude = ["ui"]
 lint.select = ["E","F","I","UP","B","SIM"]
-lint.ignore = ["E203", "E501"]
+lint.ignore = ["E203","E501"]
 lint.unfixable = ["F401"]
 
 [format]


### PR DESCRIPTION
## Summary
- move Ruff config from pyproject.toml to ruff.toml
- define linting and formatting options in ruff.toml

## Testing
- `ruff check .` (fails: 41 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b1648953e8832480147392969d708a