### PR TITLE
feat: add model manager for downloadable models

### DIFF
--- a/core/model_manager.py
+++ b/core/model_manager.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from urllib.request import urlopen
+
+
+class DownloadError(Exception):
+    """Raised when a model download fails."""
+
+
+def download_model(url: str, target: Path) -> None:
+    """Download a model from ``url`` to ``target``.
+
+    The function logs progress information and writes the file to ``target``.
+    """
+    logging.info("Downloading model from %s to %s", url, target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urlopen(url) as response:
+            total = int(response.headers.get("Content-Length", 0))
+            downloaded = 0
+            with open(target, "wb") as file:
+                while True:
+                    chunk = response.read(8192)
+                    if not chunk:
+                        break
+                    file.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        percent = downloaded / total * 100
+                        print(f"\r{percent:6.2f}% downloaded", end="")
+        if total:
+            print()
+        logging.info("Model downloaded to %s", target)
+    except Exception as exc:  # pragma: no cover - safety net
+        logging.info("Download failed: %s", exc)
+        raise DownloadError(str(exc)) from exc
+
+
+def ensure_model(name: str, category: str) -> Path:
+    """Ensure that a model exists locally, downloading if necessary.
+
+    Parameters
+    ----------
+    name:
+        Model file name.
+    category:
+        Model category used inside the ``models`` folder.
+
+    Returns
+    -------
+    Path
+        Path to the model file on disk.
+    """
+    models_dir = Path("models") / category
+    model_path = models_dir / name
+    if model_path.exists():
+        return model_path
+
+    config_path = Path("config.json")
+    config: dict = {}
+    if config_path.exists():
+        with open(config_path, "r", encoding="utf-8") as file:
+            config = json.load(file)
+
+    cached = (
+        config.get("models", {})
+        .get(category, {})
+        .get(name)
+    )
+    if cached:
+        cached_path = Path(cached)
+        if cached_path.exists():
+            return cached_path
+
+    while True:
+        consent = input(
+            f"Model '{name}' is missing. Download it? [y/N]: "
+        ).strip().lower()
+        if consent not in {"y", "yes"}:
+            raise FileNotFoundError(f"Model '{name}' is missing.")
+
+        url = input("Enter download URL: ").strip()
+        try:
+            download_model(url, model_path)
+        except DownloadError as exc:
+            print(f"Download failed: {exc}")
+            retry = input("Retry download? [y/N]: ").strip().lower()
+            if retry in {"y", "yes"}:
+                continue
+            raise
+        else:
+            config.setdefault("models", {}).setdefault(category, {})[name] = str(model_path)
+            with open(config_path, "w", encoding="utf-8") as file:
+                json.dump(config, file, indent=2)
+            return model_path

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from core.model_manager import DownloadError, ensure_model, download_model
+
+
+def test_ensure_model_existing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    model_path = Path("models/tts/existing.bin")
+    model_path.parent.mkdir(parents=True)
+    model_path.write_text("data")
+    assert ensure_model("existing.bin", "tts") == model_path
+
+
+def test_ensure_model_from_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    model_path = tmp_path / "cached.bin"
+    model_path.write_text("cached")
+    config = {"models": {"tts": {"cached.bin": str(model_path)}}}
+    Path("config.json").write_text(json.dumps(config))
+    assert ensure_model("cached.bin", "tts") == model_path
+
+
+def test_ensure_model_download(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "source.bin"
+    source.write_text("payload")
+    url = source.as_uri()
+    inputs = iter(["y", url])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    model_path = ensure_model("downloaded.bin", "tts")
+    assert model_path.exists()
+    stored = json.loads(Path("config.json").read_text())
+    assert stored["models"]["tts"]["downloaded.bin"] == str(model_path)
+
+
+def test_user_declines_download(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inputs = iter(["n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    with pytest.raises(FileNotFoundError):
+        ensure_model("missing.bin", "tts")
+
+
+def test_download_failure(tmp_path):
+    target = tmp_path / "file.bin"
+    with pytest.raises(DownloadError):
+        download_model("file:///nonexistent.bin", target)


### PR DESCRIPTION
## Summary
- add `ensure_model` and `download_model` helpers
- record downloaded model paths in `config.json`
- cover model manager behaviors with tests

## Testing
- `uv run ruff format core/model_manager.py tests/test_model_manager.py` *(fails: Failed to fetch: `https://pypi.org/simple/pydantic/`)*
- `uv run ruff check core/model_manager.py tests/test_model_manager.py` *(fails: Failed to fetch: `https://pypi.org/simple/mypy/`)*
- `uv run pytest` *(fails: Failed to fetch: `https://pypi.org/simple/python-dateutil/`)*

------
https://chatgpt.com/codex/tasks/task_b_68b1694c1d2883249da656ae166181df