### PR TITLE
Use ensure_model for Whisper weights

### DIFF
--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -1,0 +1,21 @@
+import sys
+import types
+
+import pytest
+
+from core import pipeline
+
+
+def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
+    fake_module = types.ModuleType("faster_whisper")
+    fake_module.WhisperModel = object
+    monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
+
+    def fake_ensure_model(name, category):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(pipeline, "FWHISPER", None)
+
+    with pytest.raises(RuntimeError, match="download was declined"):
+        pipeline.transcribe_whisper(tmp_path / "dummy.wav")


### PR DESCRIPTION
## Summary
- load Whisper weights via ensure_model before initializing model
- log model loading steps and raise clear error when download is declined
- add test for user refusing to download Whisper model

## Testing
- `uv run ruff check` *(fails: Failed to fetch: https://pypi.org/simple/ruff/)*
- `uv run pytest` *(fails: Failed to fetch: https://pypi.org/simple/mypy/)*

------
https://chatgpt.com/codex/tasks/task_b_68b16dd60f308324aac1df12770d1122