### PR TITLE
test: ensure transcribe_whisper loads model

### DIFF
--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -19,3 +19,27 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="download was declined"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")
+
+
+def test_transcribe_whisper_loads_existing_model(tmp_path, monkeypatch):
+    dummy_path = tmp_path / "dummy"
+
+    class DummyWhisperModel:
+        def __init__(self, model_path, *args, **kwargs):
+            self.model_path = model_path
+
+        def transcribe(self, *args, **kwargs):
+            return [], None
+
+    fake_module = types.ModuleType("faster_whisper")
+    fake_module.WhisperModel = DummyWhisperModel
+    monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
+
+    monkeypatch.setattr(pipeline, "ensure_model", lambda name, category: dummy_path)
+    monkeypatch.setattr(pipeline, "FWHISPER", None)
+
+    result = pipeline.transcribe_whisper(tmp_path / "sample.wav")
+
+    assert isinstance(pipeline.FWHISPER, DummyWhisperModel)
+    assert pipeline.FWHISPER.model_path == str(dummy_path)
+    assert isinstance(result, list) and result == []


### PR DESCRIPTION
## Summary
- add test for transcribe_whisper loading existing model

## Testing
- `ruff format tests/test_transcribe_whisper.py`
- `ruff check tests/test_transcribe_whisper.py`
- `PYTHONPATH=. pytest tests/test_transcribe_whisper.py::test_transcribe_whisper_loads_existing_model -q`
- `PYTHONPATH=. pytest tests/test_transcribe_whisper.py::test_transcribe_whisper_download_refused -q`


------
https://chatgpt.com/codex/tasks/task_b_68b17265c25883249fc2e93428e11ad8