### PR TITLE
Cache model paths for Whisper transcription

### DIFF
--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -1,6 +1,5 @@
 import sys
 import types
-
 import pytest
 
 from core import pipeline
@@ -16,6 +15,7 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
+    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
 
     with pytest.raises(RuntimeError, match="download was declined"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")
@@ -37,9 +37,42 @@ def test_transcribe_whisper_loads_existing_model(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipeline, "ensure_model", lambda name, category: dummy_path)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
+    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
 
     result = pipeline.transcribe_whisper(tmp_path / "sample.wav")
 
     assert isinstance(pipeline.FWHISPER, DummyWhisperModel)
     assert pipeline.FWHISPER.model_path == str(dummy_path)
     assert isinstance(result, list) and result == []
+
+
+def test_transcribe_whisper_uses_model_cache(tmp_path, monkeypatch):
+    dummy_path = tmp_path / "dummy"
+
+    class DummyWhisperModel:
+        def __init__(self, model_path, *args, **kwargs):
+            self.model_path = model_path
+
+        def transcribe(self, *args, **kwargs):
+            return [], None
+
+    fake_module = types.ModuleType("faster_whisper")
+    fake_module.WhisperModel = DummyWhisperModel
+    monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
+
+    calls = {"count": 0}
+
+    def fake_ensure_model(name, category):
+        calls["count"] += 1
+        return dummy_path
+
+    monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
+
+    monkeypatch.setattr(pipeline, "FWHISPER", None)
+    pipeline.transcribe_whisper(tmp_path / "first.wav")
+
+    monkeypatch.setattr(pipeline, "FWHISPER", None)
+    pipeline.transcribe_whisper(tmp_path / "second.wav")
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- cache `(model_size, category)` pairs to reuse existing model paths
- add unit test ensuring `ensure_model` invoked once when using cached model

## Testing
- `ruff check core/pipeline.py tests/test_transcribe_whisper.py` (fails: multiple style violations)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b173429d848324900153e8a73cde48