### PR TITLE
feat: centralize model downloads with GUI prompts

### DIFF
--- a/core/model_sources.py
+++ b/core/model_sources.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Mapping of official model sources.
+
+The mapping groups models by category (tts, stt, llm) and provides
+URLs to download the model archives or binaries from official
+HuggingFace or GitHub releases.
+"""
+
+MODEL_SOURCES: dict[str, dict[str, str]] = {
+    "tts": {
+        # Coqui XTTS v2 model archive on HuggingFace
+        "coqui_xtts": "https://huggingface.co/coqui/XTTS-v2/resolve/main/model.zip",
+        # Silero Russian TTS model from GitHub releases
+        "silero": "https://github.com/snakers4/silero-models/releases/download/v0.4/silero_tts_ru_v3.pt",
+    },
+    "stt": {
+        # Faster-Whisper large-v3 model weights on HuggingFace
+        "large-v3": "https://huggingface.co/guillaumekln/faster-whisper-large-v3/resolve/main/model.bin",
+    },
+    "llm": {
+        # Example lightweight instruction-tuned model on HuggingFace
+        "qwen2.5": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/resolve/main/Qwen2.5-0.5B-Instruct-q4_k_m.gguf",
+    },
+}

--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -10,7 +10,7 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
     fake_module.WhisperModel = object
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
 
-    def fake_ensure_model(name, category):
+    def fake_ensure_model(name, category, *, parent=None):
         raise FileNotFoundError("missing")
 
     monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
@@ -35,7 +35,7 @@ def test_transcribe_whisper_loads_existing_model(tmp_path, monkeypatch):
     fake_module.WhisperModel = DummyWhisperModel
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
 
-    monkeypatch.setattr(pipeline, "ensure_model", lambda name, category: dummy_path)
+    monkeypatch.setattr(pipeline, "ensure_model", lambda name, category, **kwargs: dummy_path)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
     monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
 
@@ -62,7 +62,7 @@ def test_transcribe_whisper_uses_model_cache(tmp_path, monkeypatch):
 
     calls = {"count": 0}
 
-    def fake_ensure_model(name, category):
+    def fake_ensure_model(name, category, **kwargs):
         calls["count"] += 1
         return dummy_path
 


### PR DESCRIPTION
## Summary
- add central MODEL_SOURCES registry with official URLs
- use QMessageBox in ensure_model for download confirmation and retries
- propagate parent widgets to model loading helpers

## Testing
- `ruff check core/model_manager.py core/model_sources.py core/pipeline.py core/tts_adapters.py tests/test_model_manager.py tests/test_transcribe_whisper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b1763672988324addb31f8fcfc7ccf