### PR TITLE
Add model URL validator and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Sync dependencies
         run: uv sync --all-extras --dev
 
+      - name: Validate model URLs
+        run: uv run python tools/validate_model_urls.py
+
       - name: Ruff
         run: uv run ruff check .
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,5 @@
 
 - Открывайте PR небольшими порциями.
 - Стиль кода: ruff, mypy (см. `pyproject.toml`).
+- Проверяйте модельные URL: `python tools/validate_model_urls.py`.
 - Для UI используем PySide6; без сторонних сложных фреймворков.

--- a/tests/test_model_registry_urls.py
+++ b/tests/test_model_registry_urls.py
@@ -1,0 +1,7 @@
+"""Tests for model URL validation."""
+from tools.validate_model_urls import validate_registry
+
+
+def test_model_urls_respond_ok() -> None:
+    """Model registry URLs should return 2xx on HEAD."""
+    validate_registry()

--- a/tools/validate_model_urls.py
+++ b/tools/validate_model_urls.py
@@ -1,0 +1,38 @@
+"""Validate model URLs by performing HTTP HEAD requests."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def validate_registry(registry_path: Path | None = None) -> None:
+    """Perform HTTP HEAD requests for every URL in the model registry."""
+    if registry_path is None:
+        registry_path = Path(__file__).resolve().parents[1] / "models" / "model_registry.json"
+
+    with registry_path.open("r", encoding="utf-8") as fh:
+        registry = json.load(fh)
+
+    errors: list[str] = []
+
+    for category, models in registry.items():
+        for name, urls in models.items():
+            for url in urls:
+                try:
+                    request = Request(url, method="HEAD")
+                    with urlopen(request, timeout=10) as response:
+                        status = response.getcode()
+                        if not (200 <= status < 300):
+                            errors.append(f"{category}/{name}: {url} -> {status}")
+                except (HTTPError, URLError, TimeoutError) as exc:
+                    errors.append(f"{category}/{name}: {url} -> {exc}")
+
+    if errors:
+        error_msg = "\n".join(errors)
+        raise RuntimeError(f"Model URL validation failed:\n{error_msg}")
+
+
+if __name__ == "__main__":
+    validate_registry()


### PR DESCRIPTION
## Summary
- добавить утилиту `validate_model_urls.py` с функцией `validate_registry` и тестом
- запуск проверки URL модели в CI
- упомянуть скрипт в `CONTRIBUTING.md`

## Testing
- `uv run python tools/validate_model_urls.py` (ошибка: отсутствует доступ к PyPI)
- `uv run ruff check .` (ошибка: отсутствует доступ к PyPI)
- `uv run ruff format --check .` (ошибка: отсутствует доступ к PyPI)
- `uv run mypy .` (ошибка: отсутствует доступ к PyPI)
- `uv run pytest -q` (ошибка: отсутствует доступ к PyPI)


------
https://chatgpt.com/codex/tasks/task_b_68b17be8940c83249445f853c5803ef9