### PR TITLE
feat: download Whisper model directories

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -73,16 +73,16 @@ def transcribe_whisper(
             logger.info("Ensuring Whisper model %s is available", model_size)
             try:
                 cache_key = (model_size, "stt")
-                model_path = MODEL_PATH_CACHE.get(cache_key)
-                if model_path is None:
-                    model_path = ensure_model(model_size, "stt", parent=parent)
-                    MODEL_PATH_CACHE[cache_key] = model_path
+                model_dir = MODEL_PATH_CACHE.get(cache_key)
+                if model_dir is None:
+                    model_dir = ensure_model(model_size, "stt", parent=parent)
+                    MODEL_PATH_CACHE[cache_key] = model_dir
             except FileNotFoundError as exc:
                 logger.error("Model download declined: %s", exc)
                 raise RuntimeError("Whisper model download was declined") from exc
-            logger.info("Loading Whisper model %s from %s on %s", model_size, model_path, device)
+            logger.info("Loading Whisper model %s from %s on %s", model_size, model_dir, device)
             compute_type = "int8_float16" if device == "cuda" else "int8"
-            FWHISPER = WhisperModel(str(model_path), device=device, compute_type=compute_type)
+            FWHISPER = WhisperModel(str(model_dir), device=device, compute_type=compute_type)
             FWHISPER._name = model_size
             logger.info("Whisper model %s initialized", model_size)
         assert FWHISPER is not None

--- a/models/model_registry.json
+++ b/models/model_registry.json
@@ -9,33 +9,69 @@
   },
   "stt": {
     "small": {
-      "urls": [
-        "https://huggingface.co/Systran/faster-whisper-small/resolve/main/model.bin?download=true",
-        "https://huggingface.co/guillaumekln/faster-whisper-small/resolve/main/model.bin?download=true"
+      "base_urls": [
+        "https://huggingface.co/Systran/faster-whisper-small/resolve/main/",
+        "https://huggingface.co/guillaumekln/faster-whisper-small/resolve/main/"
+      ],
+      "files": [
+        "model.bin",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocabulary.json",
+        "special_tokens_map.json"
       ],
       "description": "Fastest, lowest accuracy",
       "size_mb": 462
     },
     "medium": {
-      "urls": [
-        "https://huggingface.co/Systran/faster-whisper-medium/resolve/main/model.bin?download=true",
-        "https://huggingface.co/guillaumekln/faster-whisper-medium/resolve/main/model.bin?download=true"
+      "base_urls": [
+        "https://huggingface.co/Systran/faster-whisper-medium/resolve/main/",
+        "https://huggingface.co/guillaumekln/faster-whisper-medium/resolve/main/"
+      ],
+      "files": [
+        "model.bin",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocabulary.json",
+        "special_tokens_map.json"
       ],
       "description": "Balanced speed and accuracy",
       "size_mb": 1460
     },
     "large-v2": {
-      "urls": [
-        "https://huggingface.co/Systran/faster-whisper-large-v2/resolve/main/model.bin?download=true",
-        "https://huggingface.co/guillaumekln/faster-whisper-large-v2/resolve/main/model.bin?download=true"
+      "base_urls": [
+        "https://huggingface.co/Systran/faster-whisper-large-v2/resolve/main/",
+        "https://huggingface.co/guillaumekln/faster-whisper-large-v2/resolve/main/"
+      ],
+      "files": [
+        "model.bin",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocabulary.json",
+        "special_tokens_map.json"
       ],
       "description": "High accuracy, slower",
       "size_mb": 2890
     },
     "large-v3": {
-      "urls": [
-        "https://huggingface.co/Systran/faster-whisper-large-v3/resolve/main/model.bin?download=true",
-        "https://huggingface.co/guillaumekln/faster-whisper-large-v3/resolve/main/model.bin?download=true"
+      "base_urls": [
+        "https://huggingface.co/Systran/faster-whisper-large-v3/resolve/main/",
+        "https://huggingface.co/guillaumekln/faster-whisper-large-v3/resolve/main/"
+      ],
+      "files": [
+        "model.bin",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocabulary.json",
+        "special_tokens_map.json"
       ],
       "description": "Latest model with highest accuracy, slowest",
       "size_mb": 2920

--- a/tools/validate_model_urls.py
+++ b/tools/validate_model_urls.py
@@ -1,4 +1,5 @@
 """Validate model URLs by performing HTTP HEAD requests."""
+
 from __future__ import annotations
 
 import json
@@ -19,7 +20,14 @@ def validate_registry(registry_path: Path | None = None) -> None:
 
     for category, models in registry.items():
         for name, data in models.items():
-            urls = data.get("urls") if isinstance(data, dict) else data
+            if not isinstance(data, dict):
+                urls = data
+            elif "urls" in data:
+                urls = data["urls"]
+            else:
+                base_urls = data.get("base_urls", [])
+                files = data.get("files", [])
+                urls = [base + file for base in base_urls for file in files]
 
             for url in urls:
                 try:


### PR DESCRIPTION
## Summary
- download all Whisper files for STT models into dedicated directories
- load WhisperModel from directory paths
- validate model registry entries and add tests for STT downloads

## Testing
- `uv run --no-sync ruff format .`
- `uv run --no-sync ruff check .` *(fails: typing deprecations and import ordering across repo)*
- `uv run --no-sync pytest` *(fails: Model URL validation failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b183d08c148324bff3d96756e7a83e