### PR TITLE
feat: handle optional model files

### DIFF
--- a/models/model_registry.json
+++ b/models/model_registry.json
@@ -16,11 +16,13 @@
       "files": [
         "model.bin",
         "config.json",
-        "preprocessor_config.json",
         "tokenizer.json",
         "tokenizer_config.json",
         "vocabulary.json",
         "special_tokens_map.json"
+      ],
+      "optional_files": [
+        "preprocessor_config.json"
       ],
       "description": "Fastest, lowest accuracy",
       "size_mb": 462
@@ -83,3 +85,4 @@
     ]
   }
 }
+


### PR DESCRIPTION
## Summary
- support optional files in model manager downloads
- skip missing optional model files instead of failing
- mark Whisper small preprocessor config as optional
- test skipping of optional files

## Testing
- `uv run --no-sync ruff format core/model_manager.py tests/test_model_manager.py`
- `uv run --no-sync ruff check core/model_manager.py tests/test_model_manager.py`
- `uv run --no-sync pytest` *(fails: Model URL validation failed: tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b18acf849083248fe2a72009c461e9