### PR TITLE
feat: make tokenizer config optional

### DIFF
--- a/models/model_registry.json
+++ b/models/model_registry.json
@@ -1,88 +1,80 @@
 {
-  "tts": {
-    "coqui_xtts": [
-      "https://huggingface.co/coqui/XTTS-v2/resolve/main/model.zip"
-    ],
-    "silero": [
-      "https://models.silero.ai/models/tts/ru/v4_ru.pt"
-    ]
-  },
-  "stt": {
-    "small": {
-      "base_urls": [
-        "https://huggingface.co/Systran/faster-whisper-small/resolve/main/",
-        "https://huggingface.co/guillaumekln/faster-whisper-small/resolve/main/"
-      ],
-      "files": [
-        "model.bin",
-        "config.json",
-        "tokenizer.json",
-        "tokenizer_config.json",
-        "vocabulary.json",
-        "special_tokens_map.json"
-      ],
-      "optional_files": [
-        "preprocessor_config.json"
-      ],
-      "description": "Fastest, lowest accuracy",
-      "size_mb": 462
+    "tts": {
+        "coqui_xtts": ["https://huggingface.co/coqui/XTTS-v2/resolve/main/model.zip"],
+        "silero": ["https://models.silero.ai/models/tts/ru/v4_ru.pt"]
     },
-    "medium": {
-      "base_urls": [
-        "https://huggingface.co/Systran/faster-whisper-medium/resolve/main/",
-        "https://huggingface.co/guillaumekln/faster-whisper-medium/resolve/main/"
-      ],
-      "files": [
-        "model.bin",
-        "config.json",
-        "preprocessor_config.json",
-        "tokenizer.json",
-        "tokenizer_config.json",
-        "vocabulary.json",
-        "special_tokens_map.json"
-      ],
-      "description": "Balanced speed and accuracy",
-      "size_mb": 1460
+    "stt": {
+        "small": {
+            "base_urls": [
+                "https://huggingface.co/Systran/faster-whisper-small/resolve/main/",
+                "https://huggingface.co/guillaumekln/faster-whisper-small/resolve/main/"
+            ],
+            "files": [
+                "model.bin",
+                "config.json",
+                "tokenizer.json",
+                "vocabulary.json",
+                "special_tokens_map.json"
+            ],
+            "optional_files": ["preprocessor_config.json", "tokenizer_config.json"],
+            "description": "Fastest, lowest accuracy",
+            "size_mb": 462
+        },
+        "medium": {
+            "base_urls": [
+                "https://huggingface.co/Systran/faster-whisper-medium/resolve/main/",
+                "https://huggingface.co/guillaumekln/faster-whisper-medium/resolve/main/"
+            ],
+            "files": [
+                "model.bin",
+                "config.json",
+                "preprocessor_config.json",
+                "tokenizer.json",
+                "vocabulary.json",
+                "special_tokens_map.json"
+            ],
+            "optional_files": ["tokenizer_config.json"],
+            "description": "Balanced speed and accuracy",
+            "size_mb": 1460
+        },
+        "large-v2": {
+            "base_urls": [
+                "https://huggingface.co/Systran/faster-whisper-large-v2/resolve/main/",
+                "https://huggingface.co/guillaumekln/faster-whisper-large-v2/resolve/main/"
+            ],
+            "files": [
+                "model.bin",
+                "config.json",
+                "preprocessor_config.json",
+                "tokenizer.json",
+                "vocabulary.json",
+                "special_tokens_map.json"
+            ],
+            "optional_files": ["tokenizer_config.json"],
+            "description": "High accuracy, slower",
+            "size_mb": 2890
+        },
+        "large-v3": {
+            "base_urls": [
+                "https://huggingface.co/Systran/faster-whisper-large-v3/resolve/main/",
+                "https://huggingface.co/guillaumekln/faster-whisper-large-v3/resolve/main/"
+            ],
+            "files": [
+                "model.bin",
+                "config.json",
+                "preprocessor_config.json",
+                "tokenizer.json",
+                "vocabulary.json",
+                "special_tokens_map.json"
+            ],
+            "optional_files": ["tokenizer_config.json"],
+            "description": "Latest model with highest accuracy, slowest",
+            "size_mb": 2920
+        }
     },
-    "large-v2": {
-      "base_urls": [
-        "https://huggingface.co/Systran/faster-whisper-large-v2/resolve/main/",
-        "https://huggingface.co/guillaumekln/faster-whisper-large-v2/resolve/main/"
-      ],
-      "files": [
-        "model.bin",
-        "config.json",
-        "preprocessor_config.json",
-        "tokenizer.json",
-        "tokenizer_config.json",
-        "vocabulary.json",
-        "special_tokens_map.json"
-      ],
-      "description": "High accuracy, slower",
-      "size_mb": 2890
-    },
-    "large-v3": {
-      "base_urls": [
-        "https://huggingface.co/Systran/faster-whisper-large-v3/resolve/main/",
-        "https://huggingface.co/guillaumekln/faster-whisper-large-v3/resolve/main/"
-      ],
-      "files": [
-        "model.bin",
-        "config.json",
-        "preprocessor_config.json",
-        "tokenizer.json",
-        "tokenizer_config.json",
-        "vocabulary.json",
-        "special_tokens_map.json"
-      ],
-      "description": "Latest model with highest accuracy, slowest",
-      "size_mb": 2920
+    "llm": {
+        "qwen2.5": [
+            "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/resolve/main/Qwen2.5-0.5B-Instruct-q4_k_m.gguf"
+        ]
     }
-  },
-  "llm": {
-    "qwen2.5": [
-      "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/resolve/main/Qwen2.5-0.5B-Instruct-q4_k_m.gguf"
-    ]
-  }
 }
-

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -271,6 +271,44 @@ def test_ensure_model_skips_missing_optional_files(tmp_path, monkeypatch):
     assert not (model_dir / "extra.json").exists()
 
 
+def test_ensure_model_missing_tokenizer_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    files = ["model.bin", "config.json", "tokenizer.json"]
+    for fn in files:
+        (repo / fn).write_text("data")
+    base_url = repo.as_uri() + "/"
+    entry = {
+        "base_urls": [base_url],
+        "files": files,
+        "optional_files": ["tokenizer_config.json"],
+    }
+    monkeypatch.setattr(model_manager, "MODEL_REGISTRY", {"stt": {"dummy": entry}})
+
+    class MsgBox:
+        Yes = 1
+        No = 0
+        Retry = 2
+        Cancel = 3
+
+        @staticmethod
+        def question(*args, **kwargs):
+            return MsgBox.Yes
+
+        @staticmethod
+        def warning(*args, **kwargs):
+            return MsgBox.Cancel
+
+    monkeypatch.setattr(model_manager, "QMessageBox", MsgBox)
+
+    model_dir = ensure_model("dummy", "stt")
+    assert model_dir.is_dir()
+    for fn in files:
+        assert (model_dir / fn).exists()
+    assert not (model_dir / "tokenizer_config.json").exists()
+
+
 def test_whispermodel_loads_from_directory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- move tokenizer_config.json to optional files for whisper models
- test that missing tokenizer_config.json does not break downloads

## Testing
- `uv run --no-sync ruff format models/model_registry.json tests/test_model_manager.py`
- `uv run --no-sync ruff check tests/test_model_manager.py`
- `uv run --no-sync pytest` *(fails: Model URL validation failed: tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b18d37d1f08324a8a033d7ddd23b59