### PR TITLE
chore: adjust STT model files

### DIFF
--- a/models/model_registry.json
+++ b/models/model_registry.json
@@ -13,8 +13,7 @@
                 "model.bin",
                 "config.json",
                 "tokenizer.json",
-                "vocabulary.json",
-                "special_tokens_map.json"
+                "vocabulary.txt"
             ],
             "optional_files": ["preprocessor_config.json", "tokenizer_config.json"],
             "description": "Fastest, lowest accuracy",
@@ -28,12 +27,10 @@
             "files": [
                 "model.bin",
                 "config.json",
-                "preprocessor_config.json",
                 "tokenizer.json",
-                "vocabulary.json",
-                "special_tokens_map.json"
+                "vocabulary.txt"
             ],
-            "optional_files": ["tokenizer_config.json"],
+            "optional_files": ["preprocessor_config.json", "tokenizer_config.json"],
             "description": "Balanced speed and accuracy",
             "size_mb": 1460
         },
@@ -45,12 +42,10 @@
             "files": [
                 "model.bin",
                 "config.json",
-                "preprocessor_config.json",
                 "tokenizer.json",
-                "vocabulary.json",
-                "special_tokens_map.json"
+                "vocabulary.txt"
             ],
-            "optional_files": ["tokenizer_config.json"],
+            "optional_files": ["preprocessor_config.json", "tokenizer_config.json"],
             "description": "High accuracy, slower",
             "size_mb": 2890
         },
@@ -62,12 +57,10 @@
             "files": [
                 "model.bin",
                 "config.json",
-                "preprocessor_config.json",
                 "tokenizer.json",
-                "vocabulary.json",
-                "special_tokens_map.json"
+                "vocabulary.txt"
             ],
-            "optional_files": ["tokenizer_config.json"],
+            "optional_files": ["preprocessor_config.json", "tokenizer_config.json"],
             "description": "Latest model with highest accuracy, slowest",
             "size_mb": 2920
         }

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -162,7 +162,7 @@ def test_ensure_model_downloads_stt_repo(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    files = ["model.bin", "config.json", "tokenizer.json"]
+    files = ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]
     for fn in files:
         (repo / fn).write_text("data")
     base_url = repo.as_uri() + "/"
@@ -202,9 +202,11 @@ def test_ensure_model_converts_file_to_directory(tmp_path, monkeypatch):
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    files = ["model.bin", "config.json"]
+    files = ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]
     (repo / "model.bin").write_text("new")
     (repo / "config.json").write_text("cfg")
+    (repo / "tokenizer.json").write_text("tok")
+    (repo / "vocabulary.txt").write_text("vocab")
     base_url = repo.as_uri() + "/"
     monkeypatch.setattr(
         model_manager,
@@ -231,20 +233,22 @@ def test_ensure_model_converts_file_to_directory(tmp_path, monkeypatch):
     model_dir = ensure_model("dummy", "stt")
     assert (model_dir / "model.bin").read_text() == "old"
     assert (model_dir / "config.json").read_text() == "cfg"
+    assert (model_dir / "tokenizer.json").read_text() == "tok"
+    assert (model_dir / "vocabulary.txt").read_text() == "vocab"
 
 
 def test_ensure_model_skips_missing_optional_files(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    files = ["model.bin", "config.json"]
+    files = ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]
     for fn in files:
         (repo / fn).write_text("data")
     base_url = repo.as_uri() + "/"
     entry = {
         "base_urls": [base_url],
         "files": files,
-        "optional_files": ["extra.json"],
+        "optional_files": ["preprocessor_config.json"],
     }
     monkeypatch.setattr(model_manager, "MODEL_REGISTRY", {"stt": {"dummy": entry}})
 
@@ -268,14 +272,14 @@ def test_ensure_model_skips_missing_optional_files(tmp_path, monkeypatch):
     assert model_dir.is_dir()
     for fn in files:
         assert (model_dir / fn).exists()
-    assert not (model_dir / "extra.json").exists()
+    assert not (model_dir / "preprocessor_config.json").exists()
 
 
 def test_ensure_model_missing_tokenizer_config(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    files = ["model.bin", "config.json", "tokenizer.json"]
+    files = ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]
     for fn in files:
         (repo / fn).write_text("data")
     base_url = repo.as_uri() + "/"
@@ -313,7 +317,7 @@ def test_whispermodel_loads_from_directory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    files = ["model.bin", "config.json", "tokenizer.json"]
+    files = ["model.bin", "config.json", "tokenizer.json", "vocabulary.txt"]
     for fn in files:
         (repo / fn).write_text("data")
     base_url = repo.as_uri() + "/"


### PR DESCRIPTION
## Summary
- switch STT models to vocabulary.txt
- drop special tokens map from required files
- move preprocessor config to optional list

## Testing
- `uv run ruff check tests/test_model_manager.py models/model_registry.json`
- `uv run ruff format tests/test_model_manager.py`
- `uv run pytest` *(fails: Model URL validation failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b190b316708324b6419adf708512ce