### PR TITLE
Handle missing TTS dependencies

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -8,6 +8,7 @@ from itertools import zip_longest
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+import importlib.util
 import numpy as np
 import soundfile as sf
 from num2words import num2words
@@ -283,11 +284,21 @@ def synth_chunk(
             wav = BeepTTS().tts(text, speaker, sr=sr)
             model_sr = sr
         elif engine == "silero":
-            wav = SileroTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=sr)
-            model_sr = sr
+            if importlib.util.find_spec("torch") is None:
+                logger.warning("torch not found, falling back to BeepTTS")
+                wav = BeepTTS().tts(text, speaker, sr=sr)
+                model_sr = sr
+            else:
+                wav = SileroTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=sr)
+                model_sr = sr
         elif engine == "coqui_xtts":
-            wav = CoquiXTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=24000)
-            model_sr = 24000
+            if importlib.util.find_spec("TTS") is None or importlib.util.find_spec("torch") is None:
+                logger.warning("TTS or torch not found, falling back to BeepTTS")
+                wav = BeepTTS().tts(text, speaker, sr=sr)
+                model_sr = sr
+            else:
+                wav = CoquiXTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=24000)
+                model_sr = 24000
         elif engine == "gtts":
             wav = GTTSTTS().tts(text, speaker, sr=sr)
             model_sr = sr

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -25,7 +25,12 @@ class CoquiXTTS:
 
     def _ensure_model(self, parent: Any | None = None):
         if CoquiXTTS._model is None:
-            from TTS.api import TTS
+            try:
+                from TTS.api import TTS
+            except ModuleNotFoundError as exc:
+                raise RuntimeError(
+                    "CoquiXTTS requires the 'TTS' package with its 'torch' dependency."
+                ) from exc
 
             model_dir = ensure_model("coqui_xtts", "tts", parent=parent)
             # Load locally (offline)
@@ -71,7 +76,10 @@ class SileroTTS:
 
     def _ensure_model(self, parent: Any | None = None):
         if SileroTTS._model is None:
-            import torch
+            try:
+                import torch
+            except ModuleNotFoundError as exc:
+                raise RuntimeError("SileroTTS requires the 'torch' package.") from exc
 
             model_dir = ensure_model("silero", "tts", parent=parent)
             model_path = next(model_dir.glob("*.pt"))

--- a/tests/test_missing_deps.py
+++ b/tests/test_missing_deps.py
@@ -1,0 +1,88 @@
+import builtins
+import importlib.util as imp_util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from core import pipeline
+from core.pipeline import synth_chunk
+from core.tts_adapters import BeepTTS, CoquiXTTS, SileroTTS
+
+
+def test_silero_ensure_model_missing_torch(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch":
+            raise ModuleNotFoundError("No module named 'torch'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="torch"):
+        SileroTTS(Path("."))._ensure_model()
+
+
+def test_coqui_ensure_model_missing_tts(monkeypatch):
+    monkeypatch.delitem(sys.modules, "TTS", raising=False)
+    monkeypatch.delitem(sys.modules, "TTS.api", raising=False)
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("TTS"):
+            raise ModuleNotFoundError("No module named 'TTS'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="TTS"):
+        CoquiXTTS(Path("."))._ensure_model()
+
+
+def _setup_synth(monkeypatch, fallback_array: np.ndarray):
+    monkeypatch.setattr(pipeline, "run", lambda cmd: None)
+    storage: dict[str, np.ndarray] = {}
+
+    def fake_write(path, data, sr):
+        storage["data"] = np.array(data, dtype=np.float32)
+        storage["sr"] = sr
+
+    def fake_read(path, dtype):
+        return storage["data"], storage["sr"]
+
+    monkeypatch.setattr(pipeline.sf, "write", fake_write)
+    monkeypatch.setattr(pipeline.sf, "read", fake_read)
+    monkeypatch.setattr(BeepTTS, "tts", lambda self, text, speaker, sr: fallback_array)
+
+
+def test_synth_chunk_fallback_silero(monkeypatch, tmp_path):
+    original_find_spec = imp_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "torch":
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(imp_util, "find_spec", fake_find_spec)
+    expected = np.array([0.1, -0.1], dtype=np.float32)
+    _setup_synth(monkeypatch, expected)
+    wav = synth_chunk("ffmpeg", "hi", 16000, "spk", tmp_path, "silero")
+    np.testing.assert_array_equal(wav, expected)
+
+
+def test_synth_chunk_fallback_coqui(monkeypatch, tmp_path):
+    original_find_spec = imp_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name in {"TTS", "torch"}:
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(imp_util, "find_spec", fake_find_spec)
+    expected = np.array([0.2, -0.2], dtype=np.float32)
+    _setup_synth(monkeypatch, expected)
+    wav = synth_chunk("ffmpeg", "hi", 16000, "spk", tmp_path, "coqui_xtts")
+    np.testing.assert_array_equal(wav, expected)


### PR DESCRIPTION
## Summary
- raise clear RuntimeError when Silero or Coqui XTTS dependencies are missing
- fallback to BeepTTS in pipeline if torch/TTS modules are absent
- add tests covering dependency absence and pipeline fallback

## Testing
- `uv run ruff format core/tts_adapters.py core/pipeline.py tests/test_missing_deps.py`
- `uv run ruff check core/tts_adapters.py core/pipeline.py tests/test_missing_deps.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1974dbe988324a28c9a996ec93da8