### PR TITLE
feat: allow non-interactive model downloads

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -81,7 +81,7 @@ class SileroTTS:
             except ModuleNotFoundError as exc:
                 raise RuntimeError("SileroTTS requires the 'torch' package.") from exc
 
-            model_dir = ensure_model("silero", "tts", parent=parent)
+            model_dir = ensure_model("silero", "tts", parent=parent, auto_download=True)
             model_path = next(model_dir.glob("*.pt"))
             model = torch.package.PackageImporter(str(model_path)).load_pickle(
                 "tts_models", "model"


### PR DESCRIPTION
## Summary
- allow skipping message boxes when downloading models
- auto-download Silero TTS model without prompts
- test non-interactive model download

## Testing
- `uv run ruff check core/model_manager.py core/tts_adapters.py tests/test_model_manager.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b19bd65188832491c2618ed09a6992