### PR TITLE
feat: add model service layer

### DIFF
--- a/core/model_service.py
+++ b/core/model_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from .model_manager import ensure_model
+
+_MODEL_PATH_CACHE: Dict[Tuple[str, str], Path] = {}
+
+
+def get_model_path(
+    name: str,
+    category: str,
+    *,
+    parent: Any | None = None,
+    auto_download: bool = False,
+) -> Path:
+    key = (name, category)
+    path = _MODEL_PATH_CACHE.get(key)
+    if path is None:
+        path = ensure_model(name, category, parent=parent, auto_download=auto_download)
+        _MODEL_PATH_CACHE[key] = path
+    return path
+
+
+def clear_cache() -> None:
+    _MODEL_PATH_CACHE.clear()
+
+
+__all__ = ["get_model_path", "clear_cache"]

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -14,13 +14,13 @@ import soundfile as sf
 from num2words import num2words
 from tqdm import tqdm
 
-from .model_manager import ensure_model, DownloadError
+from .model_manager import DownloadError
+from . import model_service
 from .tts_adapters import BeepTTS, CoquiXTTS, SileroTTS, YandexTTS, GTTSTTS
 
 logger = logging.getLogger(__name__)
 
 # ===================== Global =====================
-MODEL_PATH_CACHE: dict[tuple[str, str], Path] = {}
 FWHISPER: Any | None = None
 TTS_MODEL = None
 
@@ -73,16 +73,12 @@ def transcribe_whisper(
         if need_load:
             logger.info("Ensuring Whisper model %s is available", model_size)
             try:
-                cache_key = (model_size, "stt")
-                model_dir = MODEL_PATH_CACHE.get(cache_key)
-                if model_dir is None:
-                    model_dir = ensure_model(
-                        model_size,
-                        "stt",
-                        parent=parent,
-                        auto_download=True,
-                    )
-                    MODEL_PATH_CACHE[cache_key] = model_dir
+                model_dir = model_service.get_model_path(
+                    model_size,
+                    "stt",
+                    parent=parent,
+                    auto_download=True,
+                )
             except FileNotFoundError as exc:
                 logger.error("Model download declined: %s", exc)
                 raise RuntimeError("Whisper model download was declined") from exc

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -11,7 +11,7 @@ import requests
 import soundfile as sf
 from pydub import AudioSegment
 
-from .model_manager import ensure_model
+from . import model_service
 
 __all__ = ["CoquiXTTS", "SileroTTS", "BeepTTS", "YandexTTS", "GTTSTTS"]
 
@@ -32,7 +32,9 @@ class CoquiXTTS:
                     "CoquiXTTS requires the 'TTS' package with its 'torch' dependency."
                 ) from exc
 
-            model_dir = ensure_model("coqui_xtts", "tts", parent=parent, auto_download=True)
+            model_dir = model_service.get_model_path(
+                "coqui_xtts", "tts", parent=parent, auto_download=True
+            )
             # Load locally (offline)
             CoquiXTTS._model = TTS(model_path=str(model_dir))
         return CoquiXTTS._model
@@ -81,7 +83,9 @@ class SileroTTS:
             except ModuleNotFoundError as exc:
                 raise RuntimeError("SileroTTS requires the 'torch' package.") from exc
 
-            model_dir = ensure_model("silero", "tts", parent=parent, auto_download=True)
+            model_dir = model_service.get_model_path(
+                "silero", "tts", parent=parent, auto_download=True
+            )
             model_path = next(model_dir.glob("*.pt"))
             model = torch.package.PackageImporter(str(model_path)).load_pickle(
                 "tts_models", "model"

--- a/tests/test_coqui_no_qmessagebox.py
+++ b/tests/test_coqui_no_qmessagebox.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from core import model_manager, tts_adapters
+from core import model_manager, model_service, tts_adapters
 from core.tts_adapters import CoquiXTTS
 
 
@@ -32,13 +32,13 @@ def test_coqui_ensure_model_no_qmessagebox(monkeypatch, tmp_path: Path):
 
     captured: dict[str, bool] = {}
 
-    def fake_ensure_model(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
         captured["auto_download"] = auto_download
         if not auto_download:
             model_manager.QMessageBox.question(None, "", "", 0, 0)
         return tmp_path
 
-    monkeypatch.setattr(tts_adapters, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(model_service, "get_model_path", fake_get_model_path)
 
     api_module = types.ModuleType("api")
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -343,11 +343,11 @@ def test_whispermodel_loads_from_directory(tmp_path, monkeypatch):
 
     monkeypatch.setattr(model_manager, "QMessageBox", MsgBox)
 
-    from core import pipeline
+    from core import model_service, pipeline
 
-    monkeypatch.setattr(pipeline, "ensure_model", model_manager.ensure_model)
+    monkeypatch.setattr(model_service, "get_model_path", model_manager.ensure_model)
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
     monkeypatch.setattr(pipeline, "FWHISPER", None)
-    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
 
     class DummyWhisperModel:
         def __init__(self, model_dir, *args, **kwargs):

--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -3,7 +3,7 @@ import types
 
 import pytest
 
-from core import pipeline
+from core import model_service, pipeline
 from core.model_manager import DownloadError
 
 
@@ -14,13 +14,13 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
 
     captured: dict[str, bool] = {}
 
-    def fake_ensure_model(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
         captured["auto_download"] = auto_download
         raise FileNotFoundError("missing")
 
-    monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(model_service, "get_model_path", fake_get_model_path)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
-    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
 
     with pytest.raises(RuntimeError, match="download was declined"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")
@@ -42,9 +42,9 @@ def test_transcribe_whisper_loads_existing_model(tmp_path, monkeypatch):
     fake_module.WhisperModel = DummyWhisperModel
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
 
-    monkeypatch.setattr(pipeline, "ensure_model", lambda name, category, **kwargs: dummy_path)
+    monkeypatch.setattr(model_service, "get_model_path", lambda name, category, **kwargs: dummy_path)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
-    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
 
     result = pipeline.transcribe_whisper(tmp_path / "sample.wav")
 
@@ -73,8 +73,8 @@ def test_transcribe_whisper_uses_model_cache(tmp_path, monkeypatch):
         calls["count"] += 1
         return dummy_path
 
-    monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
-    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
+    monkeypatch.setattr(model_service, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
 
     monkeypatch.setattr(pipeline, "FWHISPER", None)
     pipeline.transcribe_whisper(tmp_path / "first.wav")
@@ -92,13 +92,13 @@ def test_transcribe_whisper_download_failure(tmp_path, monkeypatch):
 
     captured: dict[str, bool] = {}
 
-    def fake_ensure_model(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
         captured["auto_download"] = auto_download
         raise DownloadError("failed")
 
-    monkeypatch.setattr(pipeline, "ensure_model", fake_ensure_model)
+    monkeypatch.setattr(model_service, "get_model_path", fake_get_model_path)
     monkeypatch.setattr(pipeline, "FWHISPER", None)
-    monkeypatch.setattr(pipeline, "MODEL_PATH_CACHE", {})
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
 
     with pytest.raises(RuntimeError, match="download failed"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")


### PR DESCRIPTION
## Summary
- centralize model path caching with new model_service.get_model_path
- use model_service in pipeline and TTS adapters
- adapt tests to mock model_service instead of ensure_model

## Testing
- `python -m py_compile core/model_service.py core/tts_adapters.py core/pipeline.py tests/test_transcribe_whisper.py tests/test_coqui_no_qmessagebox.py tests/test_model_manager.py`


------
https://chatgpt.com/codex/tasks/task_b_68b1a0aaa3588324a4c5c31e1061f8d8