### PR TITLE
feat: add torch install hint for Silero

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ uv run pytest -q
 > Silero модели ищутся в папке `models/tts/silero/` (файл `.pt`).
 > Референсы спикеров для Coqui XTTS кладите в `models/speakers/<имя>`.
 
+### Silero prerequisites
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+```
+
 - gTTS: выберите движок `gtts` в UI. Сервис не предлагает голоса и требует интернет.
 
 ---

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -81,7 +81,10 @@ class SileroTTS:
             try:
                 import torch
             except ModuleNotFoundError as exc:
-                raise RuntimeError("SileroTTS requires the 'torch' package.") from exc
+                raise RuntimeError(
+                    "SileroTTS requires the 'torch' package. "
+                    "Install it via `pip install torch --index-url https://download.pytorch.org/whl/cpu`"
+                ) from exc
 
             model_dir = model_service.get_model_path(
                 "silero", "tts", parent=parent, auto_download=True

--- a/tests/test_missing_deps.py
+++ b/tests/test_missing_deps.py
@@ -22,8 +22,11 @@ def test_silero_ensure_model_missing_torch(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    with pytest.raises(RuntimeError, match="torch"):
+    with pytest.raises(RuntimeError) as excinfo:
         SileroTTS(Path("."))._ensure_model()
+    assert "pip install torch --index-url https://download.pytorch.org/whl/cpu" in str(
+        excinfo.value
+    )
 
 
 def test_coqui_ensure_model_missing_tts(monkeypatch):


### PR DESCRIPTION
## Summary
- document Silero prerequisites
- mention torch install hint in Silero runtime error
- test missing torch hint

## Testing
- `uv run ruff check core/tts_adapters.py tests/test_missing_deps.py`
- `PYTHONPATH=. uv run pytest tests/test_missing_deps.py -k test_silero_ensure_model_missing_torch -q`

------
https://chatgpt.com/codex/tasks/task_b_68b1a1d0d950832494c57829a75fc736