### PR TITLE
feat: auto-install TTS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ uv run pytest -q
 > Silero модели ищутся в папке `models/tts/silero/` (файл `.pt`).
 > Референсы спикеров для Coqui XTTS кладите в `models/speakers/<имя>`.
 
+### Silero prerequisites
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+```
+
+### TTS dependencies
+Missing Python packages are installed automatically for TTS engines:
+
+- Silero: `torch` (`pip install torch --index-url https://download.pytorch.org/whl/cpu`)
+- Coqui XTTS: `TTS`
+- gTTS: `gTTS`
+
 - gTTS: выберите движок `gtts` в UI. Сервис не предлагает голоса и требует интернет.
 
 ---

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -12,6 +12,7 @@ import soundfile as sf
 from pydub import AudioSegment
 
 from . import model_service
+from .tts_dependencies import ensure_tts_dependencies
 
 __all__ = ["CoquiXTTS", "SileroTTS", "BeepTTS", "YandexTTS", "GTTSTTS"]
 
@@ -25,12 +26,8 @@ class CoquiXTTS:
 
     def _ensure_model(self, parent: Any | None = None):
         if CoquiXTTS._model is None:
-            try:
-                from TTS.api import TTS
-            except ModuleNotFoundError as exc:
-                raise RuntimeError(
-                    "CoquiXTTS requires the 'TTS' package with its 'torch' dependency."
-                ) from exc
+            ensure_tts_dependencies("coqui_xtts")
+            from TTS.api import TTS
 
             model_dir = model_service.get_model_path(
                 "coqui_xtts", "tts", parent=parent, auto_download=True
@@ -78,10 +75,8 @@ class SileroTTS:
 
     def _ensure_model(self, parent: Any | None = None):
         if SileroTTS._model is None:
-            try:
-                import torch
-            except ModuleNotFoundError as exc:
-                raise RuntimeError("SileroTTS requires the 'torch' package.") from exc
+            ensure_tts_dependencies("silero")
+            import torch
 
             model_dir = model_service.get_model_path(
                 "silero", "tts", parent=parent, auto_download=True
@@ -170,6 +165,7 @@ class GTTSTTS:
 
     def tts(self, text: str, speaker: str, sr: int = 48000) -> np.ndarray:
         """Synthesize speech via gTTS and resample to the desired rate."""
+        ensure_tts_dependencies("gtts")
         from gtts import gTTS
 
         buf = BytesIO()

--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from collections.abc import Mapping
+
+TTS_DEPENDENCIES: Mapping[str, dict[str, str]] = {
+    "silero": {
+        "torch": "pip install torch --index-url https://download.pytorch.org/whl/cpu",
+    },
+    "coqui_xtts": {
+        "TTS": "pip install TTS",
+    },
+    "gtts": {
+        "gtts": "pip install gTTS",
+    },
+}
+
+
+def ensure_tts_dependencies(engine: str) -> None:
+    """Ensure that required packages for a TTS engine are installed."""
+    deps = TTS_DEPENDENCIES.get(engine, {})
+    for module_name, install_cmd in deps.items():
+        try:
+            importlib.import_module(module_name)
+            continue
+        except ModuleNotFoundError as exc:
+            try:
+                subprocess.run(
+                    [sys.executable, "-m", *install_cmd.split()],
+                    check=True,
+                    capture_output=True,
+                )
+                importlib.import_module(module_name)
+            except Exception:
+                raise RuntimeError(
+                    f"{engine} requires the '{module_name}' package. Install it via `{install_cmd}`"
+                ) from exc


### PR DESCRIPTION
## Summary
- centralize TTS engine dependencies and install them on demand
- document dependency table in README
- test auto installation hints for Silero and Coqui

## Testing
- `uv run ruff check core/tts_dependencies.py core/tts_adapters.py tests/test_missing_deps.py`
- `PYTHONPATH=. uv run pytest tests/test_missing_deps.py -k "test_silero_ensure_model_missing_torch or test_coqui_ensure_model_missing_tts" -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1a1d0d950832494c57829a75fc736