### PR TITLE
Clarify Silero torch fallback warning

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -289,7 +289,9 @@ def synth_chunk(
             model_sr = sr
         elif engine == "silero":
             if importlib.util.find_spec("torch") is None:
-                logger.warning("torch not found, falling back to BeepTTS")
+                logger.warning(
+                    "Falling back to BeepTTS: install torch for Silero support"
+                )
                 wav = BeepTTS().tts(text, speaker, sr=sr)
                 model_sr = sr
             else:


### PR DESCRIPTION
## Summary
- clarify warning when Silero falls back to BeepTTS without torch
- test fallback warning

## Testing
- `PYTHONPATH=. pytest -q tests/test_missing_deps.py::test_synth_chunk_fallback_silero_warns`


------
https://chatgpt.com/codex/tasks/task_b_68b1a6d55b648324b2676c5f8bc1e4a7