### PR TITLE
feat: log torch version in SileroTTS

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+import logging
 import numpy as np
 import requests
 import soundfile as sf
@@ -77,6 +78,7 @@ class SileroTTS:
         if SileroTTS._model is None:
             try:
                 import torch
+                logging.info("Using torch %s for Silero TTS", torch.__version__)
             except ModuleNotFoundError as exc:
                 raise RuntimeError(
                     "SileroTTS requires the 'torch' package. "

--- a/tests/test_silero_tts_logging.py
+++ b/tests/test_silero_tts_logging.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from core import model_service
+from core.tts_adapters import SileroTTS
+
+
+def test_silero_logs_torch_version(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    class DummyTorch:
+        __version__ = "1.2.3"
+
+    monkeypatch.setitem(sys.modules, "torch", DummyTorch())
+
+    messages: list[str] = []
+
+    def fake_info(msg, *args, **kwargs):
+        messages.append(msg % args)
+
+    monkeypatch.setattr(logging, "info", fake_info)
+    monkeypatch.setattr(
+        model_service,
+        "get_model_path",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("stop")),
+    )
+
+    tts = SileroTTS(Path("."))
+    with pytest.raises(RuntimeError, match="stop"):
+        tts._ensure_model()
+
+    assert messages and "1.2.3" in messages[0]


### PR DESCRIPTION
## Summary
- log torch version when importing in SileroTTS
- add test ensuring torch version log is emitted

## Testing
- `python -m py_compile core/tts_adapters.py tests/test_silero_tts_logging.py`
- `PYTHONPATH=. pytest tests/test_silero_tts_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1a921471c8324a7318995155ba071