### PR TITLE
Check for uv before creating virtual environment on Windows

### DIFF
--- a/revoice_portable.bat
+++ b/revoice_portable.bat
@@ -2,6 +2,12 @@
 chcp 65001 > nul
 cd /d %~dp0
 
+where uv >nul 2>nul
+if errorlevel 1 (
+    echo "uv is required but not found. Please install uv."
+    exit /b 1
+)
+
 if not exist venv\Scripts\python.exe (
     echo Creating local virtual environment...
     uv venv venv


### PR DESCRIPTION
## Summary
- ensure uv is installed before creating virtual environment in portable batch script

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68b54d4926d08324ab98510dd46afa47