### PR TITLE
Check for uv before launching portable script

### DIFF
--- a/revoice_portable.bat
+++ b/revoice_portable.bat
@@ -11,6 +11,13 @@ set "HF_HOME=%CD%\hf_cache"
 set "HUGGINGFACE_HUB_CACHE=%HF_HOME%"
 set "TRANSFORMERS_CACHE=%HF_HOME%"
 
+where uv >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    where uv
+    echo uv is required but was not found in PATH. See https://astral.sh/uv for installation instructions.
+    exit /b 1
+)
+
 echo Starting RevoicePortable...
 uv run python -m ui.main %*
 


### PR DESCRIPTION
## Summary
- ensure `revoice_portable.bat` verifies `uv` is installed before running

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_b_68b58af316c0832490ee55cf825dcd74