### PR TITLE
feat: handle script failure

### DIFF
--- a/revoice_portable.bat
+++ b/revoice_portable.bat
@@ -19,5 +19,12 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 echo Starting RevoicePortable...
-uv run python -m ui.main %*
+(
+    uv run python -m ui.main %*
+)
+set "EXITCODE=%ERRORLEVEL%"
+if not "%EXITCODE%"=="0" (
+    echo RevoicePortable failed to start. You may be missing dependencies.
+    exit /b %EXITCODE%
+)
 


### PR DESCRIPTION
## Summary
- wrap Windows launcher in a block to capture uv exit codes
- report a helpful hint when the launcher fails

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_b_68b5910b1c54832487b9d58d8c5f2284