### PR TITLE
docs: add Silero torch requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,17 @@ uv run pytest -q
 > Silero модели ищутся в папке `models/tts/silero/` (файл `.pt`).
 > Референсы спикеров для Coqui XTTS кладите в `models/speakers/<имя>`.
 
-### Silero prerequisites
+### Silero requirements
+Silero TTS requires `torch` and `torchaudio`. Install them to avoid a BeepTTS fallback:
 ```bash
-pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
 ```
+If these packages are missing, the pipeline falls back to BeepTTS with an audible beep.
 
 ### TTS dependencies
 Missing Python packages are installed automatically for TTS engines:
 
-- Silero: `torch` (`pip install torch --index-url https://download.pytorch.org/whl/cpu`)
+- Silero: `torch` and `torchaudio` (`pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121`)
 - Coqui XTTS: `TTS`
 - gTTS: `gTTS`
 


### PR DESCRIPTION
## Summary
- document torch and torchaudio dependencies for Silero
- warn about BeepTTS fallback when missing

## Testing
- `ruff check README.md` *(fails: SyntaxError in README.md)*
- `ruff format --check README.md` *(fails: Expected a statement)*

------
https://chatgpt.com/codex/tasks/task_b_68b592be2c188324a93221417ec9b7bb