### PR TITLE
feat: add silero path resolver and jit loader

### DIFF
--- a/tests/test_silero_tts_logging.py
+++ b/tests/test_silero_tts_logging.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from core import model_service
+import core.tts_adapters as silero
 from core.tts_adapters import SileroTTS
 
 
@@ -23,8 +23,8 @@ def test_silero_logs_torch_version(monkeypatch):
 
     monkeypatch.setattr(logging, "info", fake_info)
     monkeypatch.setattr(
-        model_service,
-        "get_model_path",
+        silero,
+        "load_silero_model",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("stop")),
     )
 


### PR DESCRIPTION
## Summary
- add helper to resolve Silero model path from env, config or default
- load Silero models via torch.jit on CPU
- adjust Silero logging test for new loader

## Testing
- `PYTHONPATH=. pytest tests/test_silero_tts_logging.py::test_silero_logs_torch_version tests/test_missing_deps.py::test_silero_ensure_model_missing_torch -q`


------
https://chatgpt.com/codex/tasks/task_b_68b5a4eb882c83248f5ff5ab8127ea62