### PR TITLE
feat: add TTS engine registry with fallback

### DIFF
--- a/core/tts_registry.py
+++ b/core/tts_registry.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from collections.abc import Callable
+
+import numpy as np
+
+from .tts_adapters import BeepTTS, SileroTTS
+
+logger = logging.getLogger(__name__)
+
+
+def synthesize_silero(text: str, speaker: str, sr: int) -> np.ndarray:
+    """Synthesize speech via Silero TTS."""
+    return SileroTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=sr)
+
+
+def synthesize_beep(text: str, speaker: str, sr: int) -> np.ndarray:
+    """Fallback beep synthesis."""
+    return BeepTTS().tts(text, speaker, sr=sr)
+
+
+registry: dict[str, Callable[[str, str, int], np.ndarray]] = {
+    "silero": synthesize_silero,
+    "beep": synthesize_beep,
+}
+
+
+def get_engine(name: str | None = None) -> Callable[[str, str, int], np.ndarray]:
+    """Resolve TTS engine by name or configuration."""
+    if name is None or not name:
+        name = os.getenv("TTS_ENGINE")
+        if not name:
+            try:
+                with open("config.json", encoding="utf-8") as fh:
+                    cfg = json.load(fh)
+                name = cfg.get("tts", {}).get("engine")
+            except Exception:
+                name = None
+        name = name or "silero"
+    key = name.lower()
+    try:
+        return registry[key]
+    except KeyError:
+        return registry["beep"]


### PR DESCRIPTION
## Summary
- introduce tts registry with silero and beep engines
- centralize engine resolution via `get_engine`
- refactor pipeline to use registry and fallback to beep on silero errors

## Testing
- `ruff check core/tts_registry.py core/pipeline.py` *(fails: style warnings)*
- `python -m py_compile core/tts_registry.py core/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_68b5ab671608832481cf7bc2f6fd2f85