### PR TITLE
feat: add simple beep synthesizer

### DIFF
--- a/core/tts_registry.py
+++ b/core/tts_registry.py
@@ -3,33 +3,27 @@ from __future__ import annotations
 import json
 import logging
 import os
-from pathlib import Path
 from collections.abc import Callable
 
-import numpy as np
-
-from .tts_adapters import BeepTTS, SileroTTS
+from .tts_adapters import synthesize_beep as _synthesize_beep
+from .tts_adapters import synthesize_silero
 
 logger = logging.getLogger(__name__)
 
 
-def synthesize_silero(text: str, speaker: str, sr: int) -> np.ndarray:
-    """Synthesize speech via Silero TTS."""
-    return SileroTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=sr)
 
-
-def synthesize_beep(text: str, speaker: str, sr: int) -> np.ndarray:
+def synthesize_beep(text: str, speaker: str, sr: int) -> bytes:
     """Fallback beep synthesis."""
-    return BeepTTS().tts(text, speaker, sr=sr)
+    return _synthesize_beep(sample_rate=sr)
 
 
-registry: dict[str, Callable[[str, str, int], np.ndarray]] = {
+registry: dict[str, Callable[[str, str, int], bytes]] = {
     "silero": synthesize_silero,
     "beep": synthesize_beep,
 }
 
 
-def get_engine(name: str | None = None) -> Callable[[str, str, int], np.ndarray]:
+def get_engine(name: str | None = None) -> Callable[[str, str, int], bytes]:
     """Resolve TTS engine by name or configuration."""
     if name is None or not name:
         name = os.getenv("TTS_ENGINE")


### PR DESCRIPTION
## Summary
- add NumPy-based beep generator returning PCM16 WAV bytes
- expose beep engine via registry

## Testing
- `python -m py_compile core/tts_adapters.py core/tts_registry.py`
- `ruff check core/tts_adapters.py core/tts_registry.py`
- `python - <<'PY'
from core.tts_adapters import synthesize_beep
from core.tts_registry import registry
from io import BytesIO
import soundfile as sf
b = synthesize_beep()
data, sr = sf.read(BytesIO(b), dtype='int16')
print(data.shape, sr)
print(type(registry['beep']('', '', 48000)))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b693ec4428832481647c13bf7c4f15