### PR TITLE
feat: auto-install torch for Silero

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -208,14 +208,9 @@ class SileroTTS:
 
     def _ensure_model(self, parent: Any | None = None):
         if SileroTTS._model is None:
-            try:
-                import torch
-                logging.info("Using torch %s for Silero TTS", torch.__version__)
-            except ModuleNotFoundError as exc:
-                raise RuntimeError(
-                    "SileroTTS requires the 'torch' package. "
-                    "Install it via `pip install torch --index-url https://download.pytorch.org/whl/cpu`"
-                ) from exc
+            ensure_tts_dependencies("silero")
+            import torch
+            logging.info("Using torch %s for Silero TTS", torch.__version__)
             model_path = resolve_model_path()
             model, speakers, mode = load_silero_model(str(model_path))
             SileroTTS._model = model


### PR DESCRIPTION
## Summary
- auto-install torch when Silero TTS is selected
- refactor Silero tests to mock imports and dependency installer

## Testing
- `uv run pytest tests/test_missing_deps.py::test_silero_ensure_model_missing_torch tests/test_missing_deps.py::test_synth_chunk_fallback_silero tests/test_missing_deps.py::test_synth_chunk_fallback_silero_warns -q` *(fails: Downloading pyside6-addons (159.2MiB))*

------
https://chatgpt.com/codex/tasks/task_b_68b54393bfec8324a803a5eff1c775e8