### PR TITLE
Ensure wav array is float32 and 2D

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -330,6 +330,9 @@ def synth_chunk(
             model_sr = sr
 
         raw = tmpdir / "tts_raw.wav"
+        wav = np.asarray(wav, dtype=np.float32)
+        if wav.ndim == 1 or (wav.ndim == 2 and wav.shape[1] == 0):
+            wav = wav.reshape(-1, 1)
         sf.write(raw, wav, model_sr)
         out = tmpdir / "tts.wav"
         run(


### PR DESCRIPTION
## Summary
- ensure wav arrays are float32 and have a channel dimension before writing

## Testing
- `python -m py_compile core/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_68b943312bdc8324bf188840cfb3d5e9