### PR TITLE
test: ensure synth_chunk handles 1d audio input

### DIFF
--- a/tests/test_audio_shape_normalization.py
+++ b/tests/test_audio_shape_normalization.py
@@ -1,0 +1,22 @@
+import shutil
+
+import numpy as np
+
+import core.pipeline as pipeline
+
+
+def test_audio_shape_normalization(tmp_path, monkeypatch):
+    def fake_run(cmd):
+        shutil.copy(cmd[3], cmd[-1])
+    monkeypatch.setattr(pipeline, "run", fake_run)
+    result = pipeline.synth_chunk(
+        ffmpeg="ffmpeg",
+        text="hello",
+        sr=16000,
+        speaker="spk",
+        tmpdir=tmp_path,
+        tts_engine="beep",
+    )
+    assert (tmp_path / "tts_raw.wav").exists()
+    assert isinstance(result, np.ndarray)
+    assert result.ndim == 1


### PR DESCRIPTION
## Summary
- add regression test for synth_chunk audio shape normalization

## Testing
- `ruff check tests/test_audio_shape_normalization.py`
- `PYTHONPATH=. pytest tests/test_audio_shape_normalization.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9467d858483249f3d6fae8340f88d