### PR TITLE
Prefer real TTS; explicit control over beep fallback with clear errors

### DIFF
--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -1,0 +1,66 @@
+import logging
+import shutil
+
+import numpy as np
+import pytest
+
+from core import pipeline
+from core.tts_registry import registry
+
+
+def _copy_run(cmd):
+    shutil.copy(cmd[3], cmd[-1])
+
+
+def test_signature_detection(tmp_path, monkeypatch):
+    calls = {}
+
+    def dummy(text, speaker, sample_rate):
+        calls['sr'] = sample_rate
+        return np.zeros(10, dtype=np.float32)
+
+    monkeypatch.setattr(pipeline, 'run', _copy_run)
+    monkeypatch.setattr(pipeline, 'check_engine_available', lambda name: None)
+    monkeypatch.setitem(registry, 'dummy', dummy)
+
+    wav, reason = pipeline.synth_chunk(
+        ffmpeg='ff',
+        text='hello',
+        sr=123,
+        speaker='spk',
+        tmpdir=tmp_path,
+        tts_engine='dummy',
+        allow_beep_fallback=False,
+    )
+    assert calls['sr'] == 123
+    assert reason is None
+    assert wav.size > 0
+
+
+def test_unavailable_engine_no_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(pipeline, 'run', _copy_run)
+
+    def unavailable(name):
+        raise pipeline.TTSEngineError('missing')
+
+    monkeypatch.setattr(pipeline, 'check_engine_available', unavailable)
+    with pytest.raises(pipeline.TTSEngineError):
+        pipeline.synth_chunk(
+            'ff', 'hi', 48000, 'sp', tmp_path, 'silero', allow_beep_fallback=False
+        )
+
+
+def test_unavailable_engine_with_fallback(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(pipeline, 'run', _copy_run)
+
+    def unavailable(name):
+        raise pipeline.TTSEngineError('missing dep')
+
+    monkeypatch.setattr(pipeline, 'check_engine_available', unavailable)
+    caplog.set_level(logging.INFO)
+    wav, reason = pipeline.synth_chunk(
+        'ff', 'hi', 48000, 'sp', tmp_path, 'silero', allow_beep_fallback=True
+    )
+    assert reason == 'missing dep'
+    assert wav.size > 0
+    assert any('fallback=true' in rec.message for rec in caplog.records)

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -1,19 +1,26 @@
 from PySide6 import QtWidgets
 
 class SettingsDialog(QtWidgets.QDialog):
-    """Dialog to configure API keys for external services."""
+    """Dialog to configure API keys and options."""
 
-    def __init__(self, parent=None, yandex_key: str = "", chatgpt_key: str = ""):
+    def __init__(
+        self,
+        parent=None,
+        yandex_key: str = "",
+        chatgpt_key: str = "",
+        allow_beep_fallback: bool = False,
+    ):
         super().__init__(parent)
         self.setWindowTitle("Настройки API")
 
         form = QtWidgets.QFormLayout(self)
-        # Yandex API key input with preloaded default
         self.ed_yandex = QtWidgets.QLineEdit(yandex_key)
         form.addRow("Yandex key:", self.ed_yandex)
-        # ChatGPT API key input with preloaded default
         self.ed_chatgpt = QtWidgets.QLineEdit(chatgpt_key)
         form.addRow("ChatGPT key:", self.ed_chatgpt)
+        self.chk_beep = QtWidgets.QCheckBox("Allow beep fallback")
+        self.chk_beep.setChecked(allow_beep_fallback)
+        form.addRow(self.chk_beep)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
@@ -22,6 +29,10 @@ class SettingsDialog(QtWidgets.QDialog):
         buttons.rejected.connect(self.reject)
         form.addWidget(buttons)
 
-    def get_keys(self) -> tuple[str, str]:
-        """Return the API keys entered by the user."""
-        return self.ed_yandex.text().strip(), self.ed_chatgpt.text().strip()
+    def get_keys(self) -> tuple[str, str, bool]:
+        """Return the API keys and options entered by the user."""
+        return (
+            self.ed_yandex.text().strip(),
+            self.ed_chatgpt.text().strip(),
+            self.chk_beep.isChecked(),
+        )


### PR DESCRIPTION
## Summary
- add availability checks and logging for TTS engines
- allow explicit beep fallback via `allow_beep_fallback` setting
- surface beep fallback reason in UI and tests

## Testing
- `ruff check core/pipeline.py tests/test_tts_fallback.py tests/test_missing_deps.py`
- `mypy --follow-imports=skip core/pipeline.py tests/test_tts_fallback.py tests/test_missing_deps.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b94d26ede08324991459a8a7752b75