### PR TITLE
tests: drop tts_adapters import

### DIFF
--- a/tests/test_coqui_no_qmessagebox.py
+++ b/tests/test_coqui_no_qmessagebox.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from core import model_manager, model_service, tts_adapters
+from core import model_manager, model_service
 from core.tts_adapters import CoquiXTTS
 
 


### PR DESCRIPTION
## Summary
- remove unused tts_adapters import in Coqui test

## Testing
- `python -m py_compile tests/test_coqui_no_qmessagebox.py`
- `ruff check tests/test_coqui_no_qmessagebox.py`


------
https://chatgpt.com/codex/tasks/task_b_68b95cd992288324afc5c5f46e18c2b0