### PR TITLE
chore: remove encoding header

### DIFF
--- a/tools/fetch_tts_models.py
+++ b/tools/fetch_tts_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Скачивает TTS-модели в portable-кэш и раскладывает в D:\RevoicePortable\models\tts\...
 - Coqui XTTS v2 (мульти-язык)


### PR DESCRIPTION
## Summary
- remove unnecessary encoding declaration from fetch_tts_models

## Testing
- `python -m py_compile tools/fetch_tts_models.py`


------
https://chatgpt.com/codex/tasks/task_b_68b95d955f088324b1baba10a2fc4472