### PR TITLE
Auto-download missing speech models (Silero, Coqui XTTS, Whisper)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
   "ffmpeg_path": "bin/ffmpeg.exe",
+  "auto_download_models": true,
   "models": {
     "whisper": "models/whisper",
     "tts": {

--- a/core/model_service.py
+++ b/core/model_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -9,16 +10,27 @@ from .model_manager import ensure_model
 _MODEL_PATH_CACHE: dict[tuple[str, str], Path] = {}
 
 
+def _auto_download_enabled() -> bool:
+    try:
+        with open("config.json", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return bool(data.get("auto_download_models", True))
+    except Exception:
+        return True
+
+
 def get_model_path(
     name: str,
     category: str,
     *,
     parent: Any | None = None,
-    auto_download: bool = False,
+    auto_download: bool | None = None,
 ) -> Path:
     key = (name, category)
     path = _MODEL_PATH_CACHE.get(key)
     if path is None:
+        if auto_download is None:
+            auto_download = _auto_download_enabled()
         path = ensure_model(name, category, parent=parent, auto_download=auto_download)
         _MODEL_PATH_CACHE[key] = path
     return path

--- a/tests/test_coqui_no_qmessagebox.py
+++ b/tests/test_coqui_no_qmessagebox.py
@@ -33,9 +33,9 @@ def test_coqui_ensure_model_no_qmessagebox(monkeypatch, tmp_path: Path):
 
     captured: dict[str, bool] = {}
 
-    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=None):
         captured["auto_download"] = auto_download
-        if not auto_download:
+        if auto_download is False:
             model_manager.QMessageBox.question(None, "", "", 0, 0)
         return tmp_path
 
@@ -56,6 +56,6 @@ def test_coqui_ensure_model_no_qmessagebox(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(CoquiXTTS, "_model", None)
     CoquiXTTS(tmp_path)._ensure_model()
 
-    assert captured["auto_download"] is True
+    assert captured["auto_download"] is None
     assert msg_calls["question"] == 0
     assert msg_calls["warning"] == 0

--- a/tests/test_transcribe_whisper.py
+++ b/tests/test_transcribe_whisper.py
@@ -14,7 +14,7 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
 
     captured: dict[str, bool] = {}
 
-    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=None):
         captured["auto_download"] = auto_download
         raise FileNotFoundError("missing")
 
@@ -25,7 +25,7 @@ def test_transcribe_whisper_download_refused(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError, match="download was declined"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")
 
-    assert captured["auto_download"] is True
+    assert captured["auto_download"] is None
 
 
 def test_transcribe_whisper_loads_existing_model(tmp_path, monkeypatch):
@@ -92,7 +92,7 @@ def test_transcribe_whisper_download_failure(tmp_path, monkeypatch):
 
     captured: dict[str, bool] = {}
 
-    def fake_get_model_path(name, category, *, parent=None, auto_download=False):
+    def fake_get_model_path(name, category, *, parent=None, auto_download=None):
         captured["auto_download"] = auto_download
         raise DownloadError("failed")
 
@@ -103,5 +103,5 @@ def test_transcribe_whisper_download_failure(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError, match="download failed"):
         pipeline.transcribe_whisper(tmp_path / "dummy.wav")
 
-    assert captured["auto_download"] is True
+    assert captured["auto_download"] is None
 

--- a/ui/main.py
+++ b/ui/main.py
@@ -82,7 +82,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.yandex_key = ""
         self.chatgpt_key = ""
         self.allow_beep_fallback = False
-        self.yandex_key, self.chatgpt_key, self.allow_beep_fallback = load_config()
+        self.auto_download_models = True
+        (
+            self.yandex_key,
+            self.chatgpt_key,
+            self.allow_beep_fallback,
+            self.auto_download_models,
+        ) = load_config()
 
         log.info("UI start. Version=%s", APP_VER)
         self._build_ui()
@@ -263,10 +269,21 @@ class MainWindow(QtWidgets.QMainWindow):
             self.yandex_key,
             self.chatgpt_key,
             self.allow_beep_fallback,
+            self.auto_download_models,
         )
         if dlg.exec() == QtWidgets.QDialog.Accepted:
-            self.yandex_key, self.chatgpt_key, self.allow_beep_fallback = dlg.get_keys()
-            save_config(self.yandex_key, self.chatgpt_key, self.allow_beep_fallback)
+            (
+                self.yandex_key,
+                self.chatgpt_key,
+                self.allow_beep_fallback,
+                self.auto_download_models,
+            ) = dlg.get_keys()
+            save_config(
+                self.yandex_key,
+                self.chatgpt_key,
+                self.allow_beep_fallback,
+                self.auto_download_models,
+            )
 
     def show_help(self):
         """Show instructions for connecting Yandex API."""

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -9,6 +9,7 @@ class SettingsDialog(QtWidgets.QDialog):
         yandex_key: str = "",
         chatgpt_key: str = "",
         allow_beep_fallback: bool = False,
+        auto_download_models: bool = True,
     ):
         super().__init__(parent)
         self.setWindowTitle("Настройки API")
@@ -21,6 +22,9 @@ class SettingsDialog(QtWidgets.QDialog):
         self.chk_beep = QtWidgets.QCheckBox("Allow beep fallback")
         self.chk_beep.setChecked(allow_beep_fallback)
         form.addRow(self.chk_beep)
+        self.chk_auto = QtWidgets.QCheckBox("Auto-download models")
+        self.chk_auto.setChecked(auto_download_models)
+        form.addRow(self.chk_auto)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
@@ -29,10 +33,11 @@ class SettingsDialog(QtWidgets.QDialog):
         buttons.rejected.connect(self.reject)
         form.addWidget(buttons)
 
-    def get_keys(self) -> tuple[str, str, bool]:
+    def get_keys(self) -> tuple[str, str, bool, bool]:
         """Return the API keys and options entered by the user."""
         return (
             self.ed_yandex.text().strip(),
             self.ed_chatgpt.text().strip(),
             self.chk_beep.isChecked(),
+            self.chk_auto.isChecked(),
         )


### PR DESCRIPTION
## Summary
- add auto-download config flag and model fetch logic
- prefetch speech models via CLI with selectable engines
- load missing Silero, XTTS, Whisper models on demand

## Testing
- `ruff check core/model_service.py core/tts_adapters.py core/pipeline.py ui/config.py ui/settings.py ui/main.py tools/fetch_tts_models.py tests/test_coqui_no_qmessagebox.py tests/test_transcribe_whisper.py`
- `pytest tests/test_coqui_no_qmessagebox.py tests/test_transcribe_whisper.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b967f25734832491ec75e8859d8555