### PR TITLE
Silero TTS via torch.hub with offline cache + auto-download toggle

### DIFF
--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+import sys
+import types
+from pathlib import Path
+
+torch = types.ModuleType("torch")
+hub = types.ModuleType("torch.hub")
+hub.download_url_to_file = lambda *a, **k: None
+torch.hub = hub
+pkg = types.ModuleType("torch.package")
+pkg.PackageImporter = type("PackageImporter", (), {})
+torch.package = pkg
+torch.__version__ = "0.0"
+torch.set_num_threads = lambda *a, **k: None
+torch.device = lambda *a, **k: None
+sys.modules["torch"] = torch
+sys.modules["torch.hub"] = hub
+sys.modules["torch.package"] = pkg
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.tts_adapters import SileroTTS
+
+
+class DummyModel:
+    def apply_tts(self, *args, **kwargs):
+        return np.zeros(1, dtype=np.float32)
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+def test_silero_download_and_cache(monkeypatch, tmp_path):
+    hub = tmp_path / "hub"
+    cache_dir = hub / "snakers4_silero-models_master"
+    torch.hub.get_dir = lambda: str(hub)
+    calls = {"n": 0}
+
+    def fake_load(*args, **kwargs):
+        calls["n"] += 1
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return DummyModel(), "hi"
+
+    torch.hub.load = fake_load
+
+    SileroTTS._model = None
+    SileroTTS(tmp_path, auto_download=True).tts("hi", "baya", sr=16000)
+    SileroTTS._model = None
+    SileroTTS(tmp_path, auto_download=False).tts("hi", "baya", sr=16000)
+    assert calls["n"] == 2
+
+
+def test_silero_no_cache(monkeypatch, tmp_path):
+    hub = tmp_path / "hub"
+    torch.hub.get_dir = lambda: str(hub)
+
+    def fake_load(*args, **kwargs):
+        raise RuntimeError("missing")
+
+    torch.hub.load = fake_load
+
+    SileroTTS._model = None
+    tts = SileroTTS(tmp_path, auto_download=False)
+    with pytest.raises(RuntimeError, match="Auto-download models"):
+        tts.tts("hi", "baya", sr=16000)
+

--- a/tools/fetch_tts_models.py
+++ b/tools/fetch_tts_models.py
@@ -14,16 +14,42 @@ from core.model_manager import DownloadError, ensure_model, list_models
 
 
 def fetch(models: list[str]) -> None:
+    ok = True
     for name in models:
+        if name == "silero":
+            import torch
+
+            hub_dir = Path(torch.hub.get_dir())
+            cache_dir = hub_dir / "snakers4_silero-models_master"
+            cached_before = cache_dir.exists()
+            try:
+                torch.hub.load(
+                    repo_or_dir="snakers4/silero-models",
+                    model="silero_tts",
+                    language="ru",
+                    speaker="v4_ru",
+                    trust_repo=True,
+                    force_reload=False,
+                )
+            except Exception as exc:  # pragma: no cover - network errors
+                logging.error("silero: download failed: %s", exc)
+                ok = False
+                continue
+            action = "cached" if cached_before else "downloaded"
+            logging.info("silero: %s at %s", action, cache_dir)
+            continue
         target = ROOT / "models" / "tts" / name
         cached = target.exists()
         try:
             path = ensure_model(name, "tts", auto_download=True)
         except DownloadError as exc:  # pragma: no cover - network errors
             logging.error("%s: download failed: %s", name, exc)
+            ok = False
             continue
         action = "cached" if cached else "downloaded"
         logging.info("%s: %s at %s", name, action, path)
+    if not ok:
+        raise SystemExit(1)
 
 
 def main() -> None:

--- a/ui/main.py
+++ b/ui/main.py
@@ -368,6 +368,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 yandex_key=self.yandex_key, yandex_voice=voice,
                 speed_jitter=float(self.ed_jitter.text() or "0.03"),
                 allow_beep_fallback=self.allow_beep_fallback,
+                auto_download_models=self.auto_download_models,
             )
             if fb_reason:
                 warn = f"Used beep fallback due to: {fb_reason}"
@@ -388,14 +389,14 @@ def main():
 
     if args.say:
         from core.tts_registry import get_engine, registry
-        from core.tts_adapters import resolve_model_path
+        import torch
 
         engine_fn = get_engine()
         engine_name = next((k for k, v in registry.items() if v is engine_fn), "unknown")
         speaker = os.getenv("SILERO_SPEAKER") or "aidar"
         model_path = ""
         if engine_name == "silero":
-            model_path = str(resolve_model_path())
+            model_path = str(Path(torch.hub.get_dir()) / "snakers4_silero-models_master")
         wav = engine_fn(args.say, speaker, 48000)
         out_path = OUTPUT_DIR / "tts_test.wav"
         out_path.parent.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- load Silero via torch.hub with offline cache and explicit auto-download flag
- wire auto_download_models through pipeline and UI
- add CLI prefetch for Silero and tests for cache handling

## Testing
- `pytest tests/test_silero_cache.py::test_silero_download_and_cache tests/test_silero_cache.py::test_silero_no_cache -q`

------
https://chatgpt.com/codex/tasks/task_b_68b9711d72a88324a196bdcd51fd919d