### PR TITLE
feat: ensure silero installs omegaconf

### DIFF
--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 TTS_DEPENDENCIES: Mapping[str, dict[str, str]] = {
     "silero": {
         "torch": "pip install torch --index-url https://download.pytorch.org/whl/cpu",
+        "omegaconf": "pip install omegaconf",
     },
     "coqui_xtts": {
         "TTS": "pip install TTS",


### PR DESCRIPTION
## Summary
- include `omegaconf` as a dependency for the Silero TTS engine
- add regression test for missing `omegaconf`

## Testing
- `python -m ruff check core/tts_dependencies.py tests/test_missing_deps.py`
- `PYTHONPATH=/tmp/torch_stub:. pytest tests/test_missing_deps.py::test_silero_missing_omegaconf tests/test_missing_deps.py::test_silero_ensure_model_missing_torch -q`


------
https://chatgpt.com/codex/tasks/task_b_68b975e1d0848324ac96caa450f798a9