### PR TITLE
refactor: remove silero manual download

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ uv run pytest -q
 **Онлайн/гибрид:** Hume, gTTS, Gemini, OpenAI TTS, Minimax, Chatterbox, VibeVoice
 Сравнение: https://huggingface.co/spaces/TTS-AGI/TTS-Arena
 
-> Silero модели ищутся в папке `models/tts/silero/` (файл `.pt`).
 > Референсы спикеров для Coqui XTTS кладите в `models/speakers/<имя>`.
 
 ### Silero requirements
@@ -105,7 +104,6 @@ Missing Python packages are installed automatically for TTS engines:
 ### TTS CLI
 Переменные окружения:
 - `TTS_ENGINE` — движок (по умолчанию `silero`)
-- `SILERO_MODEL` — путь к `.pt`
 - `SILERO_SPEAKER` — имя диктора
 
 ```bash

--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,6 @@
     "whisper": "models/whisper",
     "tts": {
       "engine": "silero",
-      "silero_path": "models/tts/silero",
       "coqui_xtts_path": "models/tts/coqui_xtts",
       "dia_path": "models/tts/dia",
       "mars5_path": "models/tts/mars5",

--- a/core/model_manager.py
+++ b/core/model_manager.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.request import urlopen
 
-from torch.hub import download_url_to_file
-from torch.package import PackageImporter
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only definitions
 
@@ -277,33 +275,3 @@ def ensure_model(
     raise DownloadError(f"Failed to download model '{name}' from all registered sources")
 
 
-def ensure_model_silero() -> Any:
-    """Ensure Silero TTS model exists locally and return it."""
-    models_dir = Path("models") / "tts" / "silero"
-    model_path = models_dir / "model.pt"
-    url = "https://models.silero.ai/models/tts/ru/v4_ru.pt"
-    models_dir.mkdir(parents=True, exist_ok=True)
-    status = "cached"
-    if not model_path.exists():
-        for attempt in range(2):
-            try:
-                download_url_to_file(url, model_path)
-                if model_path.stat().st_size <= 1_000_000:
-                    raise ValueError("file too small")
-            except Exception as exc:  # pragma: no cover - safety net
-                if model_path.exists():
-                    model_path.unlink()
-                if attempt:
-                    raise DownloadError(f"Failed to download model from {url}") from exc
-            else:
-                status = "downloaded"
-                break
-    size = model_path.stat().st_size
-    model = PackageImporter(model_path).load_pickle("tts_models", "model")
-    logging.info(
-        "models.ensure name=silero status=%s path=%s size=%d",
-        status,
-        model_path,
-        size,
-    )
-    return model

--- a/models/README.md
+++ b/models/README.md
@@ -24,7 +24,8 @@
 - Поместите модели в `models/whisper` (ggml/gguf для whisper.cpp или файлы для faster-whisper).
 
 ## TTS
-- Silero, Coqui XTTS-v2, Dia, MARS5, Orpheus — каждая в своей подпапке (`models/tts/<engine>`).
+- Coqui XTTS-v2, Dia, MARS5, Orpheus — каждая в своей подпапке (`models/tts/<engine>`).
+- Silero скачивается автоматически через `torch.hub`.
 - Некоторые модели требуют GPU и значительную VRAM.
 - Референсы спикеров для Coqui XTTS кладите в `models/speakers/<имя_спикера>/` (wav-файлы).
 

--- a/models/model_registry.json
+++ b/models/model_registry.json
@@ -1,7 +1,6 @@
 {
     "tts": {
-        "coqui_xtts": ["https://huggingface.co/coqui/XTTS-v2/resolve/main/model.pth"],
-        "silero": ["https://models.silero.ai/models/tts/ru/v4_ru.pt"]
+        "coqui_xtts": ["https://huggingface.co/coqui/XTTS-v2/resolve/main/model.pth"]
     },
     "stt": {
         "small": {

--- a/tools/fetch_tts_models.py
+++ b/tools/fetch_tts_models.py
@@ -54,7 +54,7 @@ def fetch(models: list[str]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch TTS models")
-    available = sorted(list_models("tts"))
+    available = sorted({*list_models("tts"), "silero"})
     parser.add_argument(
         "--engine",
         action="append",


### PR DESCRIPTION
## Summary
- drop silero entry from model registry
- remove manual silero download helper
- update docs and config to rely on torch.hub

## Testing
- `python -m py_compile core/model_manager.py tools/fetch_tts_models.py`
- `python -m json.tool models/model_registry.json >/dev/null`
- `python -m json.tool config.example.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_b_68b976e880a083248a6e90f05692d074