### PR TITLE
test: update silero logging to torch hub

### DIFF
--- a/tests/test_silero_tts_logging.py
+++ b/tests/test_silero_tts_logging.py
@@ -1,20 +1,26 @@
 import logging
 import sys
+import types
 from pathlib import Path
 
 import pytest
 
-import core.tts_adapters as silero
 from core.tts_adapters import SileroTTS
 
 
 def test_silero_logs_torch_version(monkeypatch):
     monkeypatch.delitem(sys.modules, "torch", raising=False)
+    monkeypatch.setitem(sys.modules, "omegaconf", types.ModuleType("omegaconf"))
 
-    class DummyTorch:
-        __version__ = "1.2.3"
-
-    monkeypatch.setitem(sys.modules, "torch", DummyTorch())
+    dummy_torch = types.SimpleNamespace(
+        __version__="1.2.3",
+        set_num_threads=lambda n: None,
+        hub=types.SimpleNamespace(
+            get_dir=lambda: ".",
+            load=lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
 
     messages: list[str] = []
 
@@ -22,11 +28,6 @@ def test_silero_logs_torch_version(monkeypatch):
         messages.append(msg % args)
 
     monkeypatch.setattr(logging, "info", fake_info)
-    monkeypatch.setattr(
-        silero,
-        "load_silero_model",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("stop")),
-    )
 
     tts = SileroTTS(Path("."))
     with pytest.raises(RuntimeError, match="stop"):


### PR DESCRIPTION
## Summary
- update Silero logging test to stub torch.hub

## Testing
- `uv run ruff check tests/test_silero_tts_logging.py`
- `PYTHONPATH=. uv run pytest tests/test_silero_tts_logging.py::test_silero_logs_torch_version -q`


------
https://chatgpt.com/codex/tasks/task_b_68b97ab04b508324b177273545d5548a