### PR TITLE
feat: expose silero model cache status

### DIFF
--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -97,13 +97,18 @@ class CoquiXTTS:
 # --- Silero TTS ---
 class SileroTTS:
     _model = None
+    _status: str | None = None
 
     def __init__(self, root: Path, auto_download: bool = True):
         self.root = Path(root)
         self.auto_download = auto_download
 
     def _ensure_model(
-        self, auto_download: bool = True, parent: Any | None = None
+        self,
+        auto_download: bool = True,
+        parent: Any | None = None,
+        *,
+        return_status: bool = False,
     ):
         if SileroTTS._model is None:
             ensure_tts_dependencies("silero")
@@ -133,8 +138,10 @@ class SileroTTS:
             SileroTTS._speakers = getattr(model, "speakers", [])
             SileroTTS._mode = "offline"
             status = "cached" if cached_before else "downloaded"
+            SileroTTS._status = status
             logging.info("tts.silero ensure status=%s cache_dir=%s", status, cache_dir)
-        return SileroTTS._model
+        model = SileroTTS._model
+        return (model, SileroTTS._status) if return_status else model
 
     def tts(
         self, text: str, speaker: str, sr: int = 48000, *, parent: Any | None = None


### PR DESCRIPTION
## Summary
- capture silero TTS model cache status
- log cache path and allow optional status return
- test silero caching and logging

## Testing
- `pytest tests/test_silero_cache.py::test_silero_download_and_cache tests/test_silero_cache.py::test_silero_no_cache tests/test_silero_tts_logging.py::test_silero_logs_torch_version -q`


------
https://chatgpt.com/codex/tasks/task_b_68b97cf6d5d08324a929cb369287831b