### PR TITLE
docs: clarify Silero dependencies

### DIFF
--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -20,7 +20,10 @@ TTS_DEPENDENCIES: Mapping[str, dict[str, str]] = {
 
 
 def ensure_tts_dependencies(engine: str) -> None:
-    """Ensure that required packages for a TTS engine are installed."""
+    """Ensure that required packages for a TTS engine are installed and importable.
+
+    For example, ``ensure_tts_dependencies("silero")`` installs ``torch`` and ``omegaconf``.
+    """
     deps = TTS_DEPENDENCIES.get(engine, {})
     for module_name, install_cmd in deps.items():
         try:


### PR DESCRIPTION
## Summary
- document that `ensure_tts_dependencies("silero")` installs both torch and omegaconf

## Testing
- `pre-commit run --files core/tts_dependencies.py` *(fails: command not found)*
- `uv run pre-commit run --files core/tts_dependencies.py` *(aborted: massive dependency downloads)*
- `uv run ruff --fix core/tts_dependencies.py` *(aborted: massive dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_b_68b98115e9a483249c05c3c5a2a4b866