### PR TITLE
refactor: drop Silero root param

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -36,10 +36,7 @@ def check_engine_available(engine_name: str) -> None:
             if importlib.util.find_spec("torch") is None:
                 raise ImportError("torch not installed")
         elif engine_name == "coqui_xtts":
-            if (
-                importlib.util.find_spec("TTS") is None
-                or importlib.util.find_spec("torch") is None
-            ):
+            if importlib.util.find_spec("TTS") is None or importlib.util.find_spec("torch") is None:
                 raise ImportError("TTS or torch not installed")
             model_service.get_model_path("coqui_xtts", "tts")
         elif engine_name == "gtts":
@@ -56,6 +53,7 @@ def check_engine_available(engine_name: str) -> None:
         DownloadError,
     ) as e:
         raise TTSEngineError(str(e)) from e
+
 
 # ===================== Global =====================
 FWHISPER: Any | None = None
@@ -337,9 +335,7 @@ def synth_chunk(
     else:
         try:
             if engine_name == "coqui_xtts":
-                wav = CoquiXTTS(Path(__file__).resolve().parent.parent).tts(
-                    text, speaker, sr=24000
-                )
+                wav = CoquiXTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr=24000)
                 model_sr = 24000
             elif engine_name == "gtts":
                 wav = GTTSTTS().tts(text, speaker, sr=sr)
@@ -352,7 +348,6 @@ def synth_chunk(
                 model_sr = sr
             elif engine_name == "silero":
                 wav = SileroTTS(
-                    Path(__file__).resolve().parent.parent,
                     auto_download=auto_download_models,
                 ).tts(text, speaker, sr=sr)
                 model_sr = sr
@@ -376,13 +371,9 @@ def synth_chunk(
             ModuleNotFoundError,
         ) as e:
             if not allow_beep_fallback:
-                logger.info(
-                    "tts.engine=%s fallback=false reason=\"%s\"", engine_name, e
-                )
+                logger.info("tts.engine=%s fallback=false reason=\"%s\"", engine_name, e)
                 raise TTSEngineError(str(e)) from e
-            logger.info(
-                "tts.engine=%s fallback=true reason=\"%s\"", engine_name, e
-            )
+            logger.info("tts.engine=%s fallback=true reason=\"%s\"", engine_name, e)
             wav = BeepTTS().tts(text, speaker, sr=sr)
             model_sr = sr
             fallback_reason = str(e)
@@ -412,9 +403,7 @@ def synth_chunk(
     if not fallback_reason:
         peak = float(np.max(np.abs(wav_out)))
         rms = float(np.sqrt(np.mean(np.square(wav_out))))
-        logger.info(
-            "tts.engine=%s fallback=false peak=%.4f rms=%.4f", engine_name, peak, rms
-        )
+        logger.info("tts.engine=%s fallback=false peak=%.4f rms=%.4f", engine_name, peak, rms)
     logger.debug("synth_chunk produced %d samples", len(wav_out))
     return wav_out, fallback_reason
 
@@ -447,9 +436,7 @@ def synth_natural(
     cur_tail = 0.0
     try:
         fallback_reason: str | None = None
-        for i, (start, _end, txt) in enumerate(
-            tqdm(phrases, desc="TTS", unit="phr"), start=1
-        ):
+        for i, (start, _end, txt) in enumerate(tqdm(phrases, desc="TTS", unit="phr"), start=1):
             logger.debug("Synthesizing phrase %d", i)
             try:
                 wav, reason = synth_chunk(

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -99,8 +99,7 @@ class SileroTTS:
     _model = None
     _status: str | None = None
 
-    def __init__(self, root: Path, auto_download: bool = True):
-        self.root = Path(root)
+    def __init__(self, auto_download: bool = True):
         self.auto_download = auto_download
 
     def _ensure_model(
@@ -153,12 +152,8 @@ class SileroTTS:
     def tts(
         self, text: str, speaker: str, sr: int = 48000, *, parent: Any | None = None
     ) -> np.ndarray:
-        model = self._ensure_model(
-            auto_download=self.auto_download, parent=parent
-        )
-        wav = model.apply_tts(
-            text=text or "", speaker=speaker or "baya", sample_rate=sr
-        )
+        model = self._ensure_model(auto_download=self.auto_download, parent=parent)
+        wav = model.apply_tts(text=text or "", speaker=speaker or "baya", sample_rate=sr)
         if isinstance(wav, np.ndarray):
             arr = wav
         else:

--- a/core/tts_registry.py
+++ b/core/tts_registry.py
@@ -6,14 +6,13 @@ import os
 import wave
 from collections.abc import Callable
 from io import BytesIO
-from pathlib import Path
 
 import numpy as np
 
-from .tts_adapters import SileroTTS, synthesize_beep as _synthesize_beep
+from .tts_adapters import SileroTTS
+from .tts_adapters import synthesize_beep as _synthesize_beep
 
 logger = logging.getLogger(__name__)
-
 
 
 def synthesize_beep(text: str, speaker: str, sr: int) -> bytes:
@@ -22,7 +21,7 @@ def synthesize_beep(text: str, speaker: str, sr: int) -> bytes:
 
 
 def synthesize_silero(text: str, speaker: str, sr: int) -> bytes:
-    wav = SileroTTS(Path(__file__).resolve().parent.parent).tts(text, speaker, sr)
+    wav = SileroTTS().tts(text, speaker, sr)
     pcm16 = (np.clip(wav, -1.0, 1.0) * 32767).astype("<i2")
     buf = BytesIO()
     with wave.open(buf, "wb") as wf:

--- a/tests/test_missing_deps.py
+++ b/tests/test_missing_deps.py
@@ -35,8 +35,9 @@ def test_silero_ensure_model_missing_torch(monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
+    SileroTTS._model = None
     with pytest.raises(RuntimeError) as excinfo:
-        SileroTTS(Path("."))._ensure_model()
+        SileroTTS()._ensure_model()
     assert "pip install torch --index-url https://download.pytorch.org/whl/cpu" in str(
         excinfo.value
     )

--- a/tests/test_silero_autofetch_env.py
+++ b/tests/test_silero_autofetch_env.py
@@ -39,10 +39,9 @@ def test_env_restored(monkeypatch, tmp_path, original):
         monkeypatch.setenv("TORCH_HUB_DISABLE_AUTOFETCH", original)
 
     SileroTTS._model = None
-    SileroTTS(tmp_path, auto_download=False)._ensure_model()
+    SileroTTS(auto_download=False)._ensure_model()
 
     if original is None:
         assert "TORCH_HUB_DISABLE_AUTOFETCH" not in os.environ
     else:
         assert os.environ["TORCH_HUB_DISABLE_AUTOFETCH"] == original
-

--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -1,9 +1,12 @@
 import logging
-import numpy as np
-import pytest
 import sys
 import types
 from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 torch = types.ModuleType("torch")
 hub = types.ModuleType("torch.hub")
@@ -19,9 +22,7 @@ sys.modules["torch"] = torch
 sys.modules["torch.hub"] = hub
 sys.modules["torch.package"] = pkg
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from core.tts_adapters import SileroTTS
+from core.tts_adapters import SileroTTS  # noqa: E402
 
 
 class DummyModel:
@@ -46,7 +47,7 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
     torch.hub.load = online_load
     SileroTTS._model = None
     with caplog.at_level(logging.INFO):
-        _, status = SileroTTS(tmp_path, auto_download=True)._ensure_model(return_status=True)
+        _, status = SileroTTS(auto_download=True)._ensure_model(return_status=True)
     assert calls["online"] == 1
     assert status == "downloaded"
     assert str(cache_dir) in caplog.text
@@ -59,7 +60,7 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
 
     torch.hub.load = offline_load
     SileroTTS._model = None
-    _, status = SileroTTS(tmp_path, auto_download=False)._ensure_model(return_status=True)
+    _, status = SileroTTS(auto_download=False)._ensure_model(return_status=True)
     assert calls["offline"] == 1
     assert status == "cached"
 
@@ -74,7 +75,6 @@ def test_silero_no_cache(monkeypatch, tmp_path):
     torch.hub.load = fake_load
 
     SileroTTS._model = None
-    tts = SileroTTS(tmp_path, auto_download=False)
+    tts = SileroTTS(auto_download=False)
     with pytest.raises(RuntimeError, match="Auto-download models"):
         tts.tts("hi", "baya", sr=16000)
-

--- a/tests/test_silero_tts_logging.py
+++ b/tests/test_silero_tts_logging.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 import types
-from pathlib import Path
 
 import pytest
 
@@ -29,7 +28,8 @@ def test_silero_logs_torch_version(monkeypatch):
 
     monkeypatch.setattr(logging, "info", fake_info)
 
-    tts = SileroTTS(Path("."))
+    SileroTTS._model = None
+    tts = SileroTTS()
     with pytest.raises(RuntimeError, match="stop"):
         tts._ensure_model()
 


### PR DESCRIPTION
## Summary
- remove unused root argument from SileroTTS
- adjust pipeline, registry and tests for new signature

## Testing
- `uv run ruff check core/tts_adapters.py core/pipeline.py core/tts_registry.py tests/test_silero_autofetch_env.py tests/test_silero_tts_logging.py tests/test_silero_cache.py tests/test_missing_deps.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b9830966d883248573a4a6d371f333