### PR TITLE
feat: validate silero cache

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -35,6 +35,7 @@ def check_engine_available(engine_name: str) -> None:
             ensure_tts_dependencies("silero")
             if importlib.util.find_spec("torch") is None:
                 raise ImportError("torch not installed")
+            SileroTTS(auto_download=False)._ensure_model(auto_download=False)
         elif engine_name == "coqui_xtts":
             if importlib.util.find_spec("TTS") is None or importlib.util.find_spec("torch") is None:
                 raise ImportError("TTS or torch not installed")
@@ -51,6 +52,7 @@ def check_engine_available(engine_name: str) -> None:
         ModuleNotFoundError,
         FileNotFoundError,
         DownloadError,
+        RuntimeError,
     ) as e:
         raise TTSEngineError(str(e)) from e
 


### PR DESCRIPTION
## Summary
- ensure `check_engine_available` validates Silero model cache without auto-download
- test Silero cache requirement via `check_engine_available`

## Testing
- `ruff check core/pipeline.py tests/test_silero_cache.py`
- `pytest tests/test_silero_cache.py::test_check_engine_available_no_cache -q`


------
https://chatgpt.com/codex/tasks/task_b_68b98740af588324846cd481fe38c1f7