### PR TITLE
feat: cache Silero models in project tree

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -28,14 +28,16 @@ class TTSEngineError(RuntimeError):
     """Raised when the selected TTS engine cannot be used."""
 
 
-def check_engine_available(engine_name: str) -> None:
+def check_engine_available(engine_name: str, auto_download_models: bool = True) -> None:
     """Validate that the requested TTS engine can run."""
     try:
         if engine_name == "silero":
             ensure_tts_dependencies("silero")
             if importlib.util.find_spec("torch") is None:
                 raise ImportError("torch not installed")
-            SileroTTS(auto_download=False)._ensure_model(auto_download=False)
+            SileroTTS(auto_download=auto_download_models)._ensure_model(
+                auto_download=auto_download_models
+            )
         elif engine_name == "coqui_xtts":
             if importlib.util.find_spec("TTS") is None or importlib.util.find_spec("torch") is None:
                 raise ImportError("TTS or torch not installed")
@@ -325,7 +327,7 @@ def synth_chunk(
     logger.debug("Synthesizing chunk with engine=%s", engine_name)
     fallback_reason: str | None = None
     try:
-        check_engine_available(engine_name)
+        check_engine_available(engine_name, auto_download_models=auto_download_models)
     except TTSEngineError as e:
         if not allow_beep_fallback:
             logger.info("tts.engine=%s fallback=false reason=\"%s\"", engine_name, e)

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -114,6 +114,9 @@ class SileroTTS:
             import torch
 
             torch.set_num_threads(max(1, os.cpu_count() // 2))
+            torch_home = Path("models") / "torch_hub"
+            torch_home.mkdir(parents=True, exist_ok=True)
+            torch.hub.set_dir(str(torch_home))
             old_autofetch = os.environ.get("TORCH_HUB_DISABLE_AUTOFETCH")
             if not auto_download:
                 os.environ["TORCH_HUB_DISABLE_AUTOFETCH"] = "1"

--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 torch = types.ModuleType("torch")
 hub = types.ModuleType("torch.hub")
 hub.download_url_to_file = lambda *a, **k: None
+hub.set_dir = lambda *a, **k: None
 torch.hub = hub
 pkg = types.ModuleType("torch.package")
 pkg.PackageImporter = type("PackageImporter", (), {})
@@ -99,4 +100,4 @@ def test_check_engine_available_no_cache(monkeypatch, tmp_path):
 
     SileroTTS._model = None
     with pytest.raises(pipeline.TTSEngineError, match="Auto-download models"):
-        pipeline.check_engine_available("silero")
+        pipeline.check_engine_available("silero", auto_download_models=False)


### PR DESCRIPTION
## Summary
- store Silero TTS models inside `models/torch_hub`
- expose auto-download flag in engine availability checks
- extend Silero cache tests for custom path

## Testing
- `uv run pytest tests/test_silero_cache.py tests/test_tts_fallback.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9955aa1408324b4f47c43a9ee0e1d