### PR TITLE
feat: add language selection for Silero TTS

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
     "whisper": "models/whisper",
     "tts": {
       "engine": "silero",
+      "language": "ru",
       "coqui_xtts_path": "models/tts/coqui_xtts",
       "dia_path": "models/tts/dia",
       "mars5_path": "models/tts/mars5",

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -313,6 +313,7 @@ def synth_chunk(
     speaker: str,
     tmpdir: Path,
     tts_engine: str | None,
+    language: str = "ru",
     read_numbers: bool = False,
     spell_latin: bool = False,
     yandex_key: str | None = None,
@@ -353,6 +354,7 @@ def synth_chunk(
             elif engine_name == "silero":
                 wav = SileroTTS(
                     auto_download=auto_download_models,
+                    language=language,
                 ).tts(text, speaker, sr=sr)
                 model_sr = sr
             elif engine_name == "beep":
@@ -419,6 +421,7 @@ def synth_natural(
     speaker: str,
     tmpdir: Path,
     tts_engine: str | None,
+    language: str = "ru",
     yandex_key: str | None = None,
     yandex_voice: str | None = None,
     min_gap_sec: float = 0.30,
@@ -450,6 +453,7 @@ def synth_natural(
                     speaker,
                     tmpdir,
                     tts_engine,
+                    language,
                     read_numbers=read_numbers,
                     spell_latin=spell_latin,
                     yandex_key=yandex_key,
@@ -497,6 +501,7 @@ def revoice_video(
     duck_ratio: float = 8.0,
     duck_thresh: float = 0.05,
     tts_engine: str | None = None,
+    language: str = "ru",
     yandex_key: str | None = None,
     yandex_voice: str | None = None,
     speed_jitter: float = 0.03,
@@ -564,6 +569,7 @@ def revoice_video(
                 speaker,
                 tmp,
                 tts_engine,
+                language,
                 yandex_key=yandex_key,
                 yandex_voice=yandex_voice,
                 min_gap_sec=max(0, min_gap_ms) / 1000.0,

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -17,6 +17,27 @@ from pydub import AudioSegment
 from . import model_service
 from .tts_dependencies import ensure_tts_dependencies
 
+SILERO_LANG_MODELS = {
+    "ru": "v4_ru",
+    "en": "v3_en",
+    "de": "v3_de",
+}
+
+SILERO_VOICES = {
+    "ru": ["aidar", "baya", "kseniya", "xenia", "eugene"],
+    "en": [
+        "en_0",
+        "en_1",
+        "en_2",
+        "en_3",
+        "en_4",
+        "en_5",
+        "en_6",
+        "en_7",
+    ],
+    "de": ["de_0", "de_1", "de_2"],
+}
+
 __all__ = [
     "CoquiXTTS",
     "SileroTTS",
@@ -24,6 +45,7 @@ __all__ = [
     "YandexTTS",
     "GTTSTTS",
     "synthesize_beep",
+    "SILERO_VOICES",
 ]
 
 
@@ -96,11 +118,14 @@ class CoquiXTTS:
 
 # --- Silero TTS ---
 class SileroTTS:
-    _model = None
-    _status: str | None = None
+    _models: dict[str, Any] = {}
+    _statuses: dict[str, str | None] = {}
+    _speakers: dict[str, list[str]] = {}
+    _mode = None
 
-    def __init__(self, auto_download: bool = True):
+    def __init__(self, auto_download: bool = True, language: str = "ru"):
         self.auto_download = auto_download
+        self.language = language
 
     def _ensure_model(
         self,
@@ -109,7 +134,8 @@ class SileroTTS:
         *,
         return_status: bool = False,
     ):
-        if SileroTTS._model is None:
+        lang = self.language
+        if lang not in SileroTTS._models:
             ensure_tts_dependencies("silero")
             import torch
 
@@ -133,8 +159,8 @@ class SileroTTS:
                     model, _ = torch.hub.load(
                         repo_or_dir="snakers4/silero-models",
                         model="silero_tts",
-                        language="ru",
-                        speaker="v4_ru",
+                        language=lang,
+                        speaker=SILERO_LANG_MODELS.get(lang, "v4_ru"),
                         trust_repo=True,
                         force_reload=False,
                     )
@@ -147,25 +173,28 @@ class SileroTTS:
                         raise RuntimeError(f"Silero download failed: {e}") from e
                     raise TTSEngineError(f"Silero download failed: {e}") from e
                 model.to(torch.device("cpu"))
-                SileroTTS._model = model
-                SileroTTS._speakers = getattr(model, "speakers", [])
+                SileroTTS._models[lang] = model
+                SileroTTS._speakers[lang] = getattr(model, "speakers", [])
                 SileroTTS._mode = "offline"
                 status = "cached" if cached_before else "downloaded"
-                SileroTTS._status = status
+                SileroTTS._statuses[lang] = status
                 logging.info("tts.silero ensure status=%s cache_dir=%s", status, cache_dir)
             finally:
                 if old_autofetch is None:
                     os.environ.pop("TORCH_HUB_DISABLE_AUTOFETCH", None)
                 else:
                     os.environ["TORCH_HUB_DISABLE_AUTOFETCH"] = old_autofetch
-        model = SileroTTS._model
-        return (model, SileroTTS._status) if return_status else model
+        model = SileroTTS._models[lang]
+        status = SileroTTS._statuses.get(lang)
+        return (model, status) if return_status else model
 
     def tts(
         self, text: str, speaker: str, sr: int = 48000, *, parent: Any | None = None
     ) -> np.ndarray:
         model = self._ensure_model(auto_download=self.auto_download, parent=parent)
-        wav = model.apply_tts(text=text or "", speaker=speaker or "baya", sample_rate=sr)
+        default_voice = SILERO_VOICES.get(self.language, ["baya"])[0]
+        voice = speaker or default_voice
+        wav = model.apply_tts(text=text or "", speaker=voice, sample_rate=sr)
         if isinstance(wav, np.ndarray):
             arr = wav
         else:


### PR DESCRIPTION
## Summary
- support multiple Silero languages with model cache per language
- allow choosing language in UI and pipeline
- document TTS language in example config

## Testing
- `python -m py_compile core/tts_adapters.py core/pipeline.py ui/main.py`
- `python -m json.tool config.example.json`

------
https://chatgpt.com/codex/tasks/task_b_68b99c980b9483249fc777b2b0727e93