### PR TITLE
refactor: ensure uv handles portable startup

### DIFF
--- a/revoice_portable.bat
+++ b/revoice_portable.bat
@@ -2,13 +2,9 @@
 chcp 65001 > nul
 cd /d %~dp0
 
-@if exist ".venv\Scripts\activate.bat" (
-    call ".venv\Scripts\activate.bat"
-) else if exist "venv\Scripts\activate.bat" (
-    call "venv\Scripts\activate.bat"
-) else (
-    echo Virtual environment not found ^& exit /b 1
-)
+where uv >nul 2>&1 || (echo uv not found. Please install uv and try again. & exit /b 1)
+
+uv sync || exit /b %ERRORLEVEL%
 
 if exist "%CD%\bin" (
     set "PATH=%CD%\bin;%PATH%"
@@ -20,7 +16,7 @@ if /I "%TTS_ENGINE%"=="beep" (
 
 echo Starting RevoicePortable...
 
-python -m ui.main %*
+uv run python -m ui.main %*
 
 set "EXITCODE=%ERRORLEVEL%"
 if not "%EXITCODE%"=="0" (


### PR DESCRIPTION
## Summary
- remove virtualenv activation from revoice_portable script
- verify `uv` exists and use it for sync and runtime

## Testing
- `python -m py_compile ui/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba9a213ec88324a82f1d848397e1be