### PR TITLE
fix: use llama-cpp-python in portable launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ uv run mypy .
 uv run pytest -q
 ```
 
-- При первом запуске `revoice_portable.bat` библиотека `llama_cpp` автоматически устанавливается в папку программы (нужны интернет и свободное место на диске).
+ - При первом запуске `revoice_portable.bat` пакет `llama-cpp-python` (модуль `llama_cpp`) автоматически устанавливается в папку программы (нужны интернет и свободное место на диске).
 - Windows: запустить `revoice_portable.bat`, Linux/macOS: `./revoice_portable.sh`.
 
 ---

--- a/revoice_portable.bat
+++ b/revoice_portable.bat
@@ -23,17 +23,17 @@ if exist "%LLAMA_DIR%" (
 )
 uv run python -c "import llama_cpp  # type: ignore"
 if errorlevel 1 (
-    uv pip install llama_cpp --target "%LLAMA_DIR%"
+    uv pip install llama-cpp-python --target "%LLAMA_DIR%"
     if errorlevel 1 (
         set "EXITCODE=%ERRORLEVEL%"
-        echo Failed to install llama_cpp; AI editor won't work
+        echo Failed to install llama-cpp-python; AI editor won't work
         exit /b %EXITCODE%
     )
     set "PYTHONPATH=%LLAMA_DIR%;%PYTHONPATH%"
     uv run python -c "import llama_cpp  # type: ignore"
     if errorlevel 1 (
         set "EXITCODE=%ERRORLEVEL%"
-        echo Failed to install llama_cpp; AI editor won't work
+        echo Failed to install llama-cpp-python; AI editor won't work
         exit /b %EXITCODE%
     )
 )


### PR DESCRIPTION
## Summary
- install llama-cpp-python instead of non-existent llama_cpp in `revoice_portable.bat`
- document correct package name in README

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_b_68baa22729188324a8181df02a54b816