### PR TITLE
fix: install TTS deps before fetching models

### DIFF
--- a/tools/bootstrap_portable.py
+++ b/tools/bootstrap_portable.py
@@ -34,10 +34,9 @@ def main() -> None:
     args = parser.parse_args()
 
     engines = sorted({*list_models("tts"), "silero"})
-    fetch(list(engines))
-
     for engine in ("silero", "coqui_xtts", "gtts"):
         ensure_tts_dependencies(engine)
+    fetch(list(engines))
 
     stt_models: list[str] = []
     if args.all_stt:


### PR DESCRIPTION
## Summary
- ensure TTS dependencies are installed before model downloads

## Testing
- `python -m py_compile tools/bootstrap_portable.py`


------
https://chatgpt.com/codex/tasks/task_b_68babbf678708324a55d627d05bbe34a