### PR TITLE
Add omegaconf dependency for Silero support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 
 - Add progress display and retry logic to `tools/bootstrap_portable.py`.
 - Allow selecting a subset of TTS engines in `revoice_portable` scripts.
+- Add guidance for installing optional 'torch' dependency for Silero engine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "gtts>=2.5",
     "tqdm>=4.66",
     "num2words>=0.5",
+    "omegaconf>=2.3",
     "faster-whisper>=1.0",
     "rich>=13.7",
     "python-ffmpeg>=2.0",


### PR DESCRIPTION
## Summary
- add `omegaconf` to project dependencies
- note optional `torch` requirement for Silero engine

## Testing
- `uv sync`
- `uv run python tools/bootstrap_portable.py`
- `uv run ruff check pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_b_68babf87e68c832496dfb307cdef408d