### PR TITLE
feat: skip missing tts packages during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Missing Python packages are installed automatically for TTS engines:
 - Coqui XTTS: `TTS`
 - gTTS: `gTTS`
 
+Если установка не удалась, движок пропускается. Чтобы включить его позднее,
+установите пакет вручную, например: `pip install TTS`.
+
 
 - gTTS: выберите движок `gtts` в UI. Сервис не предлагает голоса и требует интернет.
 

--- a/tools/bootstrap_portable.py
+++ b/tools/bootstrap_portable.py
@@ -33,9 +33,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    engines = sorted({*list_models("tts"), "silero"})
-    for engine in ("silero", "coqui_xtts", "gtts"):
-        ensure_tts_dependencies(engine)
+    engines = sorted({*list_models("tts"), "silero", "gtts"})
+    for engine in engines:
+        try:
+            ensure_tts_dependencies(engine)
+        except RuntimeError as exc:  # pragma: no cover - optional deps
+            print(f"Skipping {engine} dependencies: {exc}")
     fetch(list(engines))
 
     stt_models: list[str] = []


### PR DESCRIPTION
## Summary
- continue bootstrapping when optional TTS packages are missing
- document manual installation step for TTS dependencies

## Testing
- `python -m py_compile tools/bootstrap_portable.py`


------
https://chatgpt.com/codex/tasks/task_b_68bace16da208324a10aa0e5d75a9e00