### PR TITLE
fix: align stt model bootstrap block

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - Allow selecting a subset of TTS engines in `revoice_portable` scripts.
 - Add guidance for installing optional 'torch' dependency for Silero engine.
 - Add shfmt configuration to enforce shell script style.
+- Cover `bootstrap_portable.py` with basic tests for STT model selection.

--- a/tools/bootstrap_portable.py
+++ b/tools/bootstrap_portable.py
@@ -42,7 +42,7 @@ def main() -> None:
             print(f"Skipping {engine} dependencies: {exc}")
 
     fetch(tts_models)
-   stt_models: list[str] = []
+    stt_models: list[str] = []
     if args.all_stt:
         stt_models = available_stt
     elif args.stt:


### PR DESCRIPTION
## Summary
- fix indentation for STT model prefetch block in `bootstrap_portable`
- note test coverage for STT selection in TODO

## Testing
- `python -m py_compile tools/bootstrap_portable.py`


------
https://chatgpt.com/codex/tasks/task_b_68bad1916b38832483c45cca1aee43d6