### PR TITLE
Remove redundant QwenEditor import

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,4 @@
 - Add guidance for installing optional 'torch' dependency for Silero engine.
 - Add shfmt configuration to enforce shell script style.
 - Cover `bootstrap_portable.py` with basic tests for STT model selection.
+- Make `QwenEditor` initialization optional in `ui/main.py`.

--- a/ui/main.py
+++ b/ui/main.py
@@ -56,7 +56,6 @@ except Exception as e:  # pragma: no cover - optional dependency
     _QWEN_IMPORT_ERROR = e
 else:
     _QWEN_IMPORT_ERROR = None
-from core.qwen_editor import QwenEditor
 
 YANDEX_VOICES = ["ermil","filipp","alena","jane","oksana","zahar","omazh","madirus"]
 


### PR DESCRIPTION
## Summary
- remove duplicate QwenEditor import
- note optional QwenEditor initialization

## Testing
- `python -m py_compile ui/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68bad614c0848324bdae42e7522169e7