### PR TITLE
fix: remove redundant QwenEditor initialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,4 +5,4 @@
 - Add guidance for installing optional 'torch' dependency for Silero engine.
 - Add shfmt configuration to enforce shell script style.
 - Cover `bootstrap_portable.py` with basic tests for STT model selection.
-- Make `QwenEditor` initialization optional in `ui/main.py`.
+- Notify users in the UI when `QwenEditor` is unavailable.

--- a/ui/main.py
+++ b/ui/main.py
@@ -95,7 +95,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.qwen_editor = QwenEditor()
             except Exception as err:
                 log.warning("QwenEditor init failed: %s", err)
-        self.qwen_editor = QwenEditor()
 
         # API keys for external services
         self.yandex_key = ""


### PR DESCRIPTION
## Summary
- avoid unconditional QwenEditor initialization in `MainWindow`
- note missing QwenEditor in TODO

## Testing
- `python -m py_compile ui/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68bad8bbb3a88324a0d8d83a7aaaba1e