### PR TITLE
feat: add torch fallback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,4 @@
 - Notify users in the UI when `QwenEditor` is unavailable.
 - Add optional cleanup of Hugging Face cache directory on exit.
 - Add unit tests for torch installation fallback logic in `ensure_tts_dependencies`.
+- Provide a UI warning banner when GPU acceleration is unavailable.


### PR DESCRIPTION
## Summary
- handle missing torch with a module-level flag and message
- auto-switch TTS to Beep when GPU acceleration is unavailable
- note follow-up for GPU warning banner

## Testing
- `python -m py_compile core/pipeline.py`
- `ruff check core/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_68bae325f7848324b3db37478fcf0e90