### PR TITLE
feat: ensure uv is installed for TTS deps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,4 @@
 - Add unit tests for omegaconf retry and import spec checks in `ensure_tts_dependencies`.
 - Provide a UI warning banner when GPU acceleration is unavailable.
 - Add tests for skipping Silero when torch is missing in `fetch_tts_models`.
+- Add unit tests for `ensure_uv` helper.

--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -29,11 +30,18 @@ if str(TTS_PKG_DIR) not in sys.path:
 logger = logging.getLogger(__name__)
 
 
+def ensure_uv() -> None:
+    """Ensure the uv CLI is installed."""
+    if shutil.which("uv") is None:
+        subprocess.run([sys.executable, "-m", "pip", "install", "uv"], check=True)
+
+
 def ensure_tts_dependencies(engine: str) -> None:
     """Ensure that required packages for a TTS engine are installed and importable.
 
     For example, ``ensure_tts_dependencies("silero")`` installs ``torch`` and ``omegaconf``.
     """
+    ensure_uv()
     deps = TTS_DEPENDENCIES.get(engine, {})
     for module_name, install_cmd in deps.items():
         try:


### PR DESCRIPTION
## Summary
- add ensure_uv helper to install uv if missing
- call ensure_uv before installing TTS dependencies
- document future tests for ensure_uv

## Testing
- `python -m py_compile core/tts_dependencies.py`
- `ruff check core/tts_dependencies.py`
- `PYTHONPATH=. pytest tests/test_missing_deps.py -q` *(fails: No module named 'pydub')*


------
https://chatgpt.com/codex/tasks/task_b_68be89be0bf483248170e78bc671ad18