### PR TITLE
fix: install uv within active environment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,4 @@
 - Provide a UI warning banner when GPU acceleration is unavailable.
 - Add tests for skipping Silero when torch is missing in `fetch_tts_models`.
 - Add unit tests for `ensure_uv` helper.
+- Provide clearer feedback when `uv` installation fails in `ensure_uv`.

--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -4,7 +4,6 @@ import importlib
 import importlib.util
 import logging
 import os
-import shutil
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -32,7 +31,9 @@ logger = logging.getLogger(__name__)
 
 def ensure_uv() -> None:
     """Ensure the uv CLI is installed."""
-    if shutil.which("uv") is None:
+    try:
+        import uv  # noqa: F401
+    except ModuleNotFoundError:
         subprocess.run([sys.executable, "-m", "pip", "install", "uv"], check=True)
 
 


### PR DESCRIPTION
## Summary
- ensure uv is importable before installing via pip
- note follow-up to improve uv installation feedback

## Testing
- `python -m py_compile core/tts_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_b_68be8befae188324a4345b7c4bcb42db