### PR TITLE
fix: bootstrap uv installation with ensurepip

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,3 +13,4 @@
 - Add tests for skipping Silero when torch is missing in `fetch_tts_models`.
 - Add unit tests for `ensure_uv` helper.
 - Provide clearer feedback when `uv` installation fails in `ensure_uv`.
+- Provide offline installation support for `uv` in `ensure_uv`.

--- a/core/tts_dependencies.py
+++ b/core/tts_dependencies.py
@@ -34,7 +34,25 @@ def ensure_uv() -> None:
     try:
         import uv  # noqa: F401
     except ModuleNotFoundError:
-        subprocess.run([sys.executable, "-m", "pip", "install", "uv"], check=True)
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "ensurepip", "--upgrade"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "uv"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as err:
+            logger.error(
+                "Failed to install uv\nstdout:%s\nstderr:%s",
+                err.stdout,
+                err.stderr,
+            )
 
 
 def ensure_tts_dependencies(engine: str) -> None:


### PR DESCRIPTION
## Summary
- bootstrap uv installation with ensurepip and error logging
- track offline uv installation as a future improvement

## Testing
- `uv run ruff format core/tts_dependencies.py`
- `uv run ruff check core/tts_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_b_68be9199f10883248fe6eb6e75c3c6ff