### PR TITLE
chore: refine CI dependency install and ruff scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
-      - name: Sync dependencies
-        run: uv sync --all-extras --dev
+      - name: Install dependencies
+        run: uv pip install -r requirements.txt
 
       - name: Validate model URLs
         run: uv run python tools/validate_model_urls.py
 
       - name: Ruff
-        run: uv run ruff check .
+        run: uv run ruff check core ui tests
 
       - name: Ruff format
         run: uv run ruff format --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Model loading now routes through the new `ensure_model` helper.
 - Trim default `project.dependencies` to essential packages only.
 - Rename project package to `revoice`.
+- CI installs dependencies with `uv pip install -r requirements.txt` and runs Ruff on `core`, `ui`, and `tests`.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.

--- a/TODO.md
+++ b/TODO.md
@@ -21,3 +21,4 @@
 - Populate model registry with SHA256 hashes for integrity checks.
 - Offer heavier STT/TTS packages as optional extras instead of core dependencies.
 - Format remaining source files with `ruff format`.
+- Add a pre-commit config to streamline linting and formatting.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,12 @@
 line-length = 100
 target-version = "py310"
-exclude = ["ui"]
+exclude = [
+    ".venv",
+    "venv",
+    "env",
+    "__pycache__",
+    ".ruff_cache",
+]
 lint.select = ["E","F","I","UP","B","SIM"]
 lint.ignore = ["E203","E501"]
 lint.unfixable = ["F401"]


### PR DESCRIPTION
## Summary
- streamline dependency installation with uv pip
- lint core, ui, and tests via Ruff in CI

## Changes
- install deps using `uv pip install -r requirements.txt`
- run `uv run ruff check core ui tests`
- exclude virtual env and cache folders in Ruff config

## Docs
- no README updates
- noted future work in `TODO.md`

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv pip install -r requirements.txt`
- `uv run ruff check core ui tests` *(fails: existing lint issues in ui)*

## Risks
- CI fails until `ui` directory complies with Ruff rules

## Rollback
- Revert this PR

## Checklist
- ✅ tests
- ✅ docs
- ✅ changelog
- ✅ formatting
- ❌ CI green

------
https://chatgpt.com/codex/tasks/task_b_68bedae518908324a2f71c8b7b3a3144