### PR TITLE
docs: record removal of portable mode and lazy installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed legacy bootstrap and launcher scripts.
 - Removed `faster-whisper` and `omegaconf` from core dependencies.
+- Removed portable mode.
+- Removed lazy install support.
 
 ### Docs
 - Documented installation with `uv pip`, lazy dependency/model downloads,

--- a/TODO.md
+++ b/TODO.md
@@ -23,3 +23,5 @@
 - Format remaining source files with `ruff format`.
 - Add a pre-commit config to streamline linting and formatting.
 - Add validation for `llm` and `tts_engine` configuration blocks.
+- Support optional indices for package mirrors.
+- Add advanced cache cleanup options.


### PR DESCRIPTION
## Summary
- note removal of portable mode and lazy install support
- track follow-up ideas for mirror indices and cache cleanup

## Changes
- document dropped portable mode and lazy install features in changelog
- append future improvement notes on package mirror indices and advanced cache cleanup

## Docs
- `CHANGELOG.md`
- `TODO.md`

## Changelog
- See `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run ruff check` *(fails: existing lint errors in `ui`)*

## Risks
- none

## Rollback
- revert this commit

## Checklist
- [ ] tests
- [x] docs
- [x] changelog
- [ ] formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68bedd8ed07483249d4f1cf5c4b7dbb3