### PR TITLE
feat: add silero presets and tts controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `imageio-ffmpeg` integration via `use_imageio_ffmpeg` and `externals.ffmpeg` settings for automatic FFmpeg setup.
 - `run_ui.sh` and `run_ui.bat` helper scripts for launching the UI with uv.
 - Pluggable TTS engine framework with Silero and VibeVoice engines.
+- Silero engine parameters for rate, pitch, style and preset with `.rvpreset` presets and UI selection.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI installs dependencies with `uv pip install -r requirements.txt` and runs Ruff on `core`, `ui`, and `tests`.
 - `tts_registry` now reads `tts_engine` from the top level of `config.json`.
 - TTS registry moved to `core.tts.registry` and all imports updated.
+- Silero engine now checks for `torchaudio` alongside `torch`.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.
@@ -51,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified dev dependency installation for quality checks.
 - Explain manual Silero model fetch.
 - Track VibeVoice TTS integration in TODO.
+- Explain `.rvpreset` preset loading and selection.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ uv run python -m ui.main --say "text"
 - По умолчанию: speed 0.98–1.02, pause 350–450 ms, `speed_jitter=0.03–0.05`
 - Стили: Нейтральный, Объясняющий, Рекламный, Дружелюбный
 - Кнопка «Сохранить мой пресет» → `.rvpreset`
+- `.rvpreset` из папки `presets/` загружаются при старте и дают быстрый выбор rate/pitch/style/preset
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,7 @@
 - Regenerate `uv.lock` to capture optional dependencies like `imageio-ffmpeg`.
 - Enable automated import sorting via Ruff to avoid manual fixes.
 - Consider using `uv pip sync` for reproducibility.
+- Add preset editor and saving UI for `.rvpreset` files.
 
 - Package `run_ui` scripts as a Python entry point for unified CLI launch.
 - Make Silero TTS retry attempts configurable and add exponential backoff.

--- a/core/presets.py
+++ b/core/presets.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_presets(dir_path: Path) -> dict[str, dict[str, Any]]:
+    """Load `.rvpreset` files from *dir_path*.
+
+    Each preset file should contain a JSON object with optional keys:
+    ``rate``, ``pitch``, ``style`` and ``preset``.
+    The file name (without extension) is used as the preset name.
+    Invalid files are ignored.
+    """
+    presets: dict[str, dict[str, Any]] = {}
+    if not dir_path.exists():
+        return presets
+    for path in dir_path.glob("*.rvpreset"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                presets[path.stem] = data
+        except Exception:
+            continue
+    return presets

--- a/core/tts/engines/base.py
+++ b/core/tts/engines/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
 
@@ -13,7 +14,7 @@ class TTSEngineBase(ABC):
         """Load engine resources."""
 
     @abstractmethod
-    def synthesize(self, text: str, speaker: str, sample_rate: int) -> np.ndarray:
+    def synthesize(self, text: str, speaker: str, sample_rate: int, **kwargs: Any) -> np.ndarray:
         """Synthesize *text* with *speaker* at *sample_rate* and return waveform."""
 
     @abstractmethod

--- a/core/tts/engines/beep_engine.py
+++ b/core/tts/engines/beep_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from ...tts_adapters import BeepTTS
@@ -15,7 +17,7 @@ class BeepEngine(TTSEngineBase):
     def load(self) -> None:
         self._impl = BeepTTS()
 
-    def synthesize(self, text: str, speaker: str, sample_rate: int) -> np.ndarray:
+    def synthesize(self, text: str, speaker: str, sample_rate: int, **kwargs: Any) -> np.ndarray:
         if self._impl is None:
             self.load()
         assert self._impl is not None

--- a/core/tts/engines/silero_engine.py
+++ b/core/tts/engines/silero_engine.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+from typing import Any
 
 import numpy as np
 
+from ...pkg_installer import ensure_package
 from ...tts_adapters import SILERO_VOICES, SileroTTS
 from .base import TTSEngineBase
 
@@ -17,13 +19,40 @@ class SileroEngine(TTSEngineBase):
         self._impl: SileroTTS | None = None
 
     def load(self) -> None:
+        try:
+            ensure_package("torch", "torch is required for Silero TTS.")
+            ensure_package("torchaudio", "torchaudio is required for Silero TTS.")
+        except ModuleNotFoundError as exc:  # pragma: no cover - dependency handling
+            raise RuntimeError(str(exc)) from exc
         self._impl = SileroTTS(auto_download=self.auto_download, language=self.language)
 
-    def synthesize(self, text: str, speaker: str, sample_rate: int) -> np.ndarray:
+    def synthesize(
+        self,
+        text: str,
+        speaker: str,
+        sample_rate: int,
+        rate: float | None = None,
+        pitch: float | None = None,
+        style: str | None = None,
+        preset: str | None = None,
+        **_: Any,
+    ) -> np.ndarray:
         if self._impl is None:
             self.load()
         assert self._impl is not None
-        wav = self._impl.tts(text, speaker, sr=sample_rate)
+        if rate is not None and not (0.5 <= rate <= 2.0):
+            raise ValueError("rate must be between 0.5 and 2.0")
+        if pitch is not None and not (-10.0 <= pitch <= 10.0):
+            raise ValueError("pitch must be between -10.0 and 10.0")
+        wav = self._impl.tts(
+            text,
+            speaker,
+            sr=sample_rate,
+            rate=rate,
+            pitch=pitch,
+            style=style,
+            preset=preset,
+        )
         return np.asarray(wav, dtype=np.float32)
 
     def unload(self) -> None:
@@ -37,5 +66,6 @@ class SileroEngine(TTSEngineBase):
     def is_available(cls) -> bool:
         return (
             importlib.util.find_spec("torch") is not None
+            and importlib.util.find_spec("torchaudio") is not None
             and importlib.util.find_spec("omegaconf") is not None
         )

--- a/core/tts/engines/vibevoice.py
+++ b/core/tts/engines/vibevoice.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from io import BytesIO
+from typing import Any
 
 import numpy as np
 import soundfile as sf
@@ -28,7 +29,7 @@ class VibeVoiceEngine(TTSEngineBase):
     def load(self) -> None:  # noqa: D401 - simple
         pass
 
-    def synthesize(self, text: str, speaker: str, sample_rate: int) -> np.ndarray:
+    def synthesize(self, text: str, speaker: str, sample_rate: int, **kwargs: Any) -> np.ndarray:
         cmd = [
             self.options.executable,
             "--text",

--- a/presets/neutral.rvpreset
+++ b/presets/neutral.rvpreset
@@ -1,0 +1,6 @@
+{
+  "rate": 1.0,
+  "pitch": 0.0,
+  "style": null,
+  "preset": "neutral"
+}

--- a/tests/test_missing_deps.py
+++ b/tests/test_missing_deps.py
@@ -19,6 +19,7 @@ from core.tts_dependencies import ensure_tts_dependencies
 def test_silero_ensure_model_missing_torch(monkeypatch):
     monkeypatch.delitem(sys.modules, "torch", raising=False)
     monkeypatch.setitem(sys.modules, "omegaconf", types.ModuleType("omegaconf"))
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
     original_import = importlib.import_module
 
     def fake_import(name, *args, **kwargs):
@@ -47,6 +48,7 @@ def test_silero_ensure_model_missing_torch(monkeypatch):
 def test_silero_missing_omegaconf(monkeypatch):
     monkeypatch.delitem(sys.modules, "omegaconf", raising=False)
     monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
     original_import = importlib.import_module
 
     def fake_import(name, *args, **kwargs):

--- a/tests/test_silero_autofetch_env.py
+++ b/tests/test_silero_autofetch_env.py
@@ -32,6 +32,7 @@ def test_env_restored(monkeypatch, tmp_path, original):
         device=lambda *a, **k: None,
     )
     monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
 
     if original is None:
         monkeypatch.delenv("TORCH_HUB_DISABLE_AUTOFETCH", raising=False)

--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -23,6 +23,7 @@ sys.modules["torch"] = torch
 sys.modules["torch.hub"] = hub
 sys.modules["torch.package"] = pkg
 sys.modules["omegaconf"] = types.ModuleType("omegaconf")
+sys.modules["torchaudio"] = types.ModuleType("torchaudio")
 
 from core import pipeline, pkg_installer  # noqa: E402
 from core.tts_adapters import SileroTTS  # noqa: E402

--- a/tests/test_silero_params.py
+++ b/tests/test_silero_params.py
@@ -1,0 +1,44 @@
+import types
+
+import numpy as np
+import pytest
+
+from core.tts.engines.silero_engine import SileroEngine
+
+
+def test_silero_engine_param_mapping(monkeypatch):
+    captured = {}
+
+    def fake_tts(text, speaker, sr, **kwargs):  # type: ignore[unused-argument]
+        captured.update(kwargs)
+        return np.zeros(1, dtype=np.float32)
+
+    def fake_load(self):
+        self._impl = types.SimpleNamespace(tts=fake_tts)
+
+    monkeypatch.setattr(SileroEngine, "load", fake_load)
+    engine = SileroEngine()
+    wav = engine.synthesize(
+        "hi",
+        "baya",
+        16000,
+        rate=1.1,
+        pitch=0.2,
+        style="foo.wav",
+        preset="bar",
+    )
+    assert wav.shape[0] == 1
+    assert captured["rate"] == 1.1
+    assert captured["pitch"] == 0.2
+    assert captured["style"] == "foo.wav" or captured.get("style_wav") == "foo.wav"
+    assert captured["preset"] == "bar"
+
+
+def test_silero_engine_rate_validation(monkeypatch):
+    def fake_load(self):
+        self._impl = types.SimpleNamespace(tts=lambda *a, **k: np.zeros(1, dtype=np.float32))
+
+    monkeypatch.setattr(SileroEngine, "load", fake_load)
+    engine = SileroEngine()
+    with pytest.raises(ValueError):
+        engine.synthesize("hi", "baya", 16000, rate=0.1)

--- a/tests/test_silero_tts_logging.py
+++ b/tests/test_silero_tts_logging.py
@@ -20,6 +20,7 @@ def test_silero_logs_torch_version(monkeypatch):
         ),
     )
     monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
 
     messages: list[str] = []
 


### PR DESCRIPTION
## Summary
- add rate, pitch, style and preset options to Silero engine
- load `.rvpreset` files and expose preset selector in the UI
- check for `torchaudio` dependency when using Silero

## Changes
- map new options to `model.apply_tts` with validation
- support `.rvpreset` loading and quick preset selection
- add explicit `torch`/`torchaudio` checks

## Docs
- README updated with `.rvpreset` usage
- TODO item added for preset editor

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run ruff check core/tts/engines/base.py core/tts/engines/beep_engine.py core/tts/engines/vibevoice.py core/tts/engines/silero_engine.py core/tts_adapters.py core/pipeline.py core/presets.py ui/main.py tests/test_missing_deps.py tests/test_silero_autofetch_env.py tests/test_silero_cache.py tests/test_silero_tts_logging.py tests/test_silero_params.py`
- `uv run ruff format core/tts/engines/base.py core/tts/engines/beep_engine.py core/tts/engines/vibevoice.py core/tts/engines/silero_engine.py core/tts_adapters.py core/pipeline.py core/presets.py ui/main.py tests/test_missing_deps.py tests/test_silero_autofetch_env.py tests/test_silero_cache.py tests/test_silero_tts_logging.py tests/test_silero_params.py --check`
- `uv run mypy core/tts/engines/silero_engine.py core/tts_adapters.py core/pipeline.py core/presets.py` *(fails: unused type ignores in core modules)*
- `uv run pytest -q` *(fails: multiple existing tests)*

## Risks
- presets with invalid values may raise validation errors
- missing `torchaudio` still prevents Silero engine use

## Rollback
- Revert this PR

## Checklist
- [x] tests
- [x] docs
- [x] changelog
- [x] formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c286603fd08324ba3719870f613928