### PR TITLE
test: expand dialogue and registry coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deterministic per-speaker seeding and optional `silence_gap_ms` insertion.
 - Autosave checkpoints with crash/OOM resume support.
 - Optional GPU offload with peak VRAM/time logging.
+- Tests for dialogue parsing, Russian text segmentation, and TTS engine registry with GPU VibeVoice integration test.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.

--- a/TODO.md
+++ b/TODO.md
@@ -48,3 +48,4 @@
 - Extend Silero registry to cover more languages and voices.
 - Support more than four speakers in script parser.
 - Persist checkpoints per project instead of single file.
+- Add CI coverage for VibeVoice GPU integration test.

--- a/tests/test_merge_into_phrases.py
+++ b/tests/test_merge_into_phrases.py
@@ -17,3 +17,16 @@ def test_merge_into_phrases_sorts_segments():
         (1.5, 1.6, "C"),
     ]
 
+
+def test_merge_into_phrases_handles_russian_text():
+    segs = [
+        (0.0, 0.5, "Привет"),
+        (0.5, 1.0, "мир!"),
+        (1.5, 2.0, "До"),
+        (2.0, 2.5, "свидания"),
+    ]
+    res = pipeline.merge_into_phrases(segs, max_gap=0.4, min_len=0.1)
+    assert res == [
+        (0.0, 1.0, "Привет мир!"),
+        (1.5, 2.5, "До свидания"),
+    ]

--- a/tests/test_script_parser.py
+++ b/tests/test_script_parser.py
@@ -3,16 +3,26 @@ import pytest
 from core.script_parser import parse_script, split_chunks
 
 
-def test_parse_script_valid():
-    script = "Speaker 1: Hello world\nSpeaker 2: Hi there"
+@pytest.mark.parametrize("speaker_count", [1, 2, 3, 4])
+def test_parse_script_handles_up_to_four_speakers(speaker_count):
+    script = "\n".join(f"Speaker {i}: line {i}" for i in range(1, speaker_count + 1))
     lines = parse_script(script)
-    assert [line.speaker for line in lines] == [1, 2]
-    assert [line.text for line in lines] == ["Hello world", "Hi there"]
+    assert [line.speaker for line in lines] == list(range(1, speaker_count + 1))
 
 
-def test_parse_script_invalid():
+@pytest.mark.parametrize(
+    "bad_line",
+    [
+        "Speaker 0: nope",
+        "Speaker 5: nope",
+        "Speaker one: nope",
+        "Speaker 1 nope",
+        "Speaker 1:",
+    ],
+)
+def test_parse_script_rejects_invalid_formats(bad_line):
     with pytest.raises(ValueError):
-        parse_script("Speaker 5: Too many")
+        parse_script(bad_line)
 
 
 def test_split_chunks():

--- a/tests/test_tts_registry.py
+++ b/tests/test_tts_registry.py
@@ -1,0 +1,24 @@
+import importlib
+
+import pytest
+
+tts_registry = importlib.import_module("core.tts.registry")
+from core.tts.engines import BeepEngine, SileroEngine, VibeVoiceEngine
+
+
+def _reset_loaded():
+    tts_registry._loaded.clear()
+
+
+def test_get_engine_returns_correct_classes():
+    _reset_loaded()
+    assert isinstance(tts_registry.get_engine("silero"), SileroEngine)
+    _reset_loaded()
+    assert isinstance(tts_registry.get_engine("beep"), BeepEngine)
+    _reset_loaded()
+    assert isinstance(tts_registry.get_engine("vibevoice"), VibeVoiceEngine)
+
+
+def test_get_engine_unknown_falls_back_to_beep():
+    _reset_loaded()
+    assert isinstance(tts_registry.get_engine("unknown"), BeepEngine)

--- a/tests/test_vibevoice_integration.py
+++ b/tests/test_vibevoice_integration.py
@@ -1,0 +1,36 @@
+import shutil
+
+import numpy as np
+import pytest
+
+from core.script_parser import parse_script, split_chunks
+from core.tts.engines.vibevoice import VibeVoiceEngine
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None
+
+
+@pytest.mark.skipif(
+    torch is None or not torch.cuda.is_available() or shutil.which("vibe-voice") is None,
+    reason="vibe-voice binary and CUDA GPU required",
+)
+def test_vibevoice_long_dialogue():
+    before = torch.cuda.memory_allocated(0)
+    lines = [f"Speaker {1 if i % 2 == 0 else 2}: слово{i}" for i in range(750)]
+    script = "\n".join(lines)
+    parsed = parse_script(script)
+    chunks = split_chunks(parsed, min_sec=30, max_sec=60)
+    engine = VibeVoiceEngine()
+    engine.load()
+    wavs = []
+    for chunk in chunks:
+        text = " ".join(line.text for line in chunk)
+        wavs.append(engine.synthesize(text, speaker="0", sample_rate=48000))
+    audio = np.concatenate(wavs)
+    assert audio.size > 0
+    engine.unload()
+    torch.cuda.empty_cache()
+    after = torch.cuda.memory_allocated(0)
+    assert after <= before


### PR DESCRIPTION
## Summary
- add dialogue parser tests for 1-4 speakers and invalid formats
- cover Russian segmentation and TTS engine registry
- add GPU-conditional VibeVoice integration test

## Changes
- expand script parser tests for valid and invalid dialogues
- add Russian merge test and registry resolution checks
- introduce long-dialogue VibeVoice GPU test skeleton
- update changelog and todo

## Docs
- no README updates
- added TODO entry for GPU CI coverage

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run pytest tests/test_script_parser.py tests/test_merge_into_phrases.py tests/test_tts_registry.py tests/test_vibevoice_integration.py -q`

## Risks
- integration test requires GPU and vibe-voice binary; skipped otherwise

## Rollback
- Revert the commit via `git revert`

## Checklist
- ✅ tests
- ✅ docs
- ✅ changelog
- ✅ formatting
- ✅ CI green

------
https://chatgpt.com/codex/tasks/task_b_68c2a47735508324aa7fa813292e90cc