### PR TITLE
docs: add VibeVoice and timeline guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explain `.rvpreset` preset loading and selection.
 - Document structured TTS configuration keys.
 - Mention script parser, autosave and offload options in README.
+- Added VibeVoice and timeline guides; expanded README with uv quick start, model fetch commands, and engine toggle examples.

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ If these packages are missing, the pipeline falls back to BeepTTS with an audibl
 Download models for offline use:
 ```bash
 # Silero voice pack
-python tools/fetch_tts_models.py silero --language en
+uv run python tools/fetch_tts_models.py silero --language en
 
 # VibeVoice weights
-python tools/fetch_tts_models.py vibevoice --model 1.5b
+uv run python tools/fetch_tts_models.py vibevoice --model 1.5b
 
 # Models from registry (e.g. Coqui XTTS)
-python tools/fetch_tts_models.py registry --engine coqui_xtts
+uv run python tools/fetch_tts_models.py registry --engine coqui_xtts
 ```
 Downloads use local cache and show progress bars. If a fetch fails with SSL
 errors, ensure your system certificates are installed or set `SSL_CERT_FILE` to a
@@ -148,8 +148,10 @@ Missing Python packages are installed automatically into `.venv` for TTS engines
 - `SILERO_SPEAKER` — имя диктора
 
 ```bash
-uv run python -m ui.main --say "text"
-# появится output/tts_test.wav
+uv run python -m ui.main --say "text"                     # default engine
+TTS_ENGINE=silero   uv run python -m ui.main --say "Hello"
+TTS_ENGINE=vibevoice uv run python -m ui.main --say "Hello"
+# output: output/tts_test.wav
 ```
 
 ---
@@ -217,10 +219,15 @@ uv run pytest -q
 ```bash
 # 1) Установить uv и Python 3.10–3.12
 # 2) Установить зависимости
-uv sync --all-extras --frozen
-# 3) Запустить UI
+uv pip install -r requirements.txt
+# 3) Скачать модель TTS (пример: VibeVoice 1.5B)
+uv run python tools/fetch_tts_models.py vibevoice --model 1.5b
+# 4) Запустить UI
 uv run python -m ui.main
-# 4) (Опционально) установить imageio-ffmpeg или положить ffmpeg в ./bin либо PATH — при отсутствии скачивается автоматически
+# 5) Переключить движок из CLI
+TTS_ENGINE=silero   uv run python -m ui.main --say "Hello"
+TTS_ENGINE=vibevoice uv run python -m ui.main --say "Hello"
+# 6) (Опционально) imageio-ffmpeg или свой ffmpeg в ./bin либо PATH
 ```
 
 ## Лицензия

--- a/TODO.md
+++ b/TODO.md
@@ -49,3 +49,5 @@
 - Support more than four speakers in script parser.
 - Persist checkpoints per project instead of single file.
 - Add CI coverage for VibeVoice GPU integration test.
+- Add screenshots or diagrams to timeline guide.
+- Automate VRAM usage benchmarking for VibeVoice models.

--- a/docs/tts_vibevoice.md
+++ b/docs/tts_vibevoice.md
@@ -1,0 +1,32 @@
+# VibeVoice TTS Guide
+
+## Model variants
+- **300M** – light variant for CPU or low VRAM GPUs.
+- **1.5B** – full quality model (~9.5 GB VRAM in fp16).
+- **1.5B Q8** – int8 quantized weights (~5 GB VRAM).
+
+## Attention backends
+- `sdpa` – default PyTorch scaled dot-product attention.
+- `flash` – FlashAttention 2; fastest on NVIDIA Ampere+ GPUs.
+- `torch` – fall-back implementation when others are unavailable.
+
+## VRAM usage
+| Model | Backend | Precision | Approx VRAM |
+|-------|---------|-----------|-------------|
+|300M   | sdpa    | fp16      | ~2 GB|
+|1.5B   | sdpa    | fp16      | ~9.5 GB|
+|1.5B   | flash   | int8      | ~5 GB|
+
+VRAM varies with batch size and sequence length. Use the smallest model and quantization that meet your quality needs.
+
+## Quantization
+- `fp16`/`bf16` – highest quality; requires most VRAM.
+- `int8` – balances quality and size; good default for GPUs.
+- `int4` – experimental; largest speed/VRAM savings with quality trade-offs.
+
+## Long-form tips
+- Chunk long scripts into 30–60 s segments to limit memory spikes.
+- Enable `tts.autosave_minutes` to checkpoint progress for lengthy jobs.
+- Set `tts.force_offload=true` to release GPU memory between segments.
+- Prefer quantized weights when generating hours of audio.
+- Log peak VRAM usage to tune model/precision for your hardware.

--- a/docs/ui_timeline.md
+++ b/docs/ui_timeline.md
@@ -1,0 +1,22 @@
+# UI Timeline Guide
+
+## Features
+- Multi-track timeline with Video, Voice, Music, and SFX lanes.
+- Trim, split, and speed controls for clips.
+- Markers and zoom for precise navigation.
+- Export to H.264/H.265 with optional embedded subtitles.
+
+## Hotkeys
+- `Space` – play/pause.
+- `Ctrl+Enter` – render selection.
+- `Ctrl+Wheel` – zoom in/out.
+- `Ctrl+Z` / `Ctrl+Y` – undo/redo edits.
+
+## A/B comparison
+- Toggle between original and synthesized audio with two linked players.
+- Waveform view highlights differences between takes.
+
+## Mixer options
+- Per-track volume sliders with mute/solo buttons.
+- Ducking sidechain keeps voice clear over music.
+- Optional SFX track for Foley and stingers.


### PR DESCRIPTION
## Summary
- document VibeVoice TTS models and timeline UI
- refresh README with uv quick start, model fetch, and engine toggle examples

## Changes
- add `docs/tts_vibevoice.md` and `docs/ui_timeline.md`
- expand README with uv-based quick start, model downloads, and engine toggles
- update changelog and todo lists

## Docs
- `README.md`
- `docs/tts_vibevoice.md`
- `docs/ui_timeline.md`
- `TODO.md`

## Changelog
- see `[Unreleased]` > `Docs`

## Test Plan
- `uv run ruff check .` *(fails: tests/test_tts_registry.py unused import and import order)*

## Risks
- none; docs only

## Rollback
- Revert commit `docs: add VibeVoice and timeline guides`

## Checklist
- [ ] tests
- [x] docs
- [x] changelog
- [x] formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2a7a7cc3c832497768d5ee842939f