### PR TITLE
feat: add vibevoice engine in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autosave checkpoints with crash/OOM resume support.
 - Optional GPU offload with peak VRAM/time logging.
 - Tests for dialogue parsing, Russian text segmentation, and TTS engine registry with GPU VibeVoice integration test.
+- VibeVoice engine selectable in UI with dynamic speaker listing and missing binary warning.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Missing Python packages are installed automatically into `.venv` for TTS engines
 
 
 - gTTS: выберите движок `gtts` в UI. Сервис не предлагает голоса и требует интернет.
+- VibeVoice: выберите движок `vibevoice` в UI. Требует установленного бинаря `vibe-voice`.
 
 ### TTS CLI
 Переменные окружения:

--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,4 @@
 - Add CI coverage for VibeVoice GPU integration test.
 - Add screenshots or diagrams to timeline guide.
 - Automate VRAM usage benchmarking for VibeVoice models.
+- Add UI tests for VibeVoice speaker listing and binary warning.

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -4,6 +4,7 @@ import json
 import logging
 import random
 import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -49,6 +50,9 @@ def check_engine_available(engine_name: str, auto_download_models: bool = True) 
             ensure_package("gTTS", "gTTS is required for gtts.")
         elif engine_name == "yandex":
             pass
+        elif engine_name == "vibevoice":
+            if shutil.which("vibe-voice") is None:
+                raise FileNotFoundError("vibe-voice binary not found. Install VibeVoice.")
         else:
             ensure_package(engine_name, f"{engine_name} is required.")
     except ModuleNotFoundError as e:
@@ -63,6 +67,7 @@ def check_engine_available(engine_name: str, auto_download_models: bool = True) 
         DownloadError,
         RuntimeError,
     ) as e:
+        QMessageBox.warning(None, "Missing dependency", str(e))
         raise TTSEngineError(str(e)) from e
 
 

--- a/ui/main.py
+++ b/ui/main.py
@@ -194,8 +194,8 @@ class MainWindow(QtWidgets.QMainWindow):
         row = 0
 
         self.cmb_engine = QtWidgets.QComboBox()
-        # Include gTTS among available engines
-        self.cmb_engine.addItems(["silero", "yandex", "coqui_xtts", "gtts"])
+        # Include gTTS and VibeVoice among available engines
+        self.cmb_engine.addItems(["silero", "yandex", "coqui_xtts", "gtts", "vibevoice"])
         self.cmb_engine.currentTextChanged.connect(self._on_engine_change)
         grid.addWidget(QtWidgets.QLabel("Движок TTS:"), row, 0)
         grid.addWidget(self.cmb_engine, row, 1)
@@ -383,6 +383,27 @@ class MainWindow(QtWidgets.QMainWindow):
             self.cmb_language.hide()
             self.lbl_preset.hide()
             self.cmb_preset.hide()
+        elif engine == "vibevoice":
+            self.lbl_voice.setText("VibeVoice voice:")
+            self.cmb_voice.setEditable(False)
+            self.lbl_language.hide()
+            self.cmb_language.hide()
+            self.lbl_preset.hide()
+            self.cmb_preset.hide()
+            try:
+                result = subprocess.run(
+                    ["vibe-voice", "--list-speakers"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+            except FileNotFoundError:
+                QMessageBox.warning(self, "Missing binary", "vibe-voice executable not found. Install VibeVoice.")
+            except subprocess.CalledProcessError as e:
+                QMessageBox.warning(self, "vibe-voice error", str(e))
+            else:
+                voices = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+                self.cmb_voice.addItems(voices)
         elif engine == "gtts":
             # gTTS has no preset voices, so hide the selector
             self.lbl_voice.hide()


### PR DESCRIPTION
## Summary
- expose VibeVoice engine in the UI
- load speakers via `vibe-voice --list-speakers` and warn when binary is missing
- guard pipeline against absent `vibe-voice` binary

## Changes
- add `vibevoice` option to engine selector and fetch speakers through CLI
- show warning if `vibe-voice` is not found and skip speaker list
- verify `vibe-voice` availability in `check_engine_available`
- document VibeVoice engine in README and changelog
- note UI test idea for VibeVoice speaker listing in TODO

## Docs
- updated `README.md`
- added TODO entry in `TODO.md`

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run ruff check ui/main.py core/pipeline.py`
- `uv run pytest tests/test_tts_registry.py -q`
- `python - <<'PY' ...` (mock `QMessageBox` and ensure warning is triggered)

## Risks
- VibeVoice CLI output format may change
- missing `vibe-voice` binary still prevents synthesis

## Rollback
- revert this commit via `git revert`

## Checklist
- [x] tests (if needed)
- [x] docs
- [x] changelog
- [x] formatting
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2acc2cb6883249318a6a6bf397e00