### PR TITLE
feat: use cached Silero TTS models offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TTS registry moved to `core.tts.registry` and all imports updated.
 - Silero engine now checks for `torchaudio` alongside `torch`.
 - Configuration now uses `tts.default_engine` instead of top-level `tts_engine`.
+- Silero TTS now uses the local torch hub cache when available and disables autofetch to avoid network access.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu1
 ```
 If these packages are missing, the pipeline falls back to BeepTTS with an audible beep.
 
+If `models/torch_hub/snakers4_silero-models_master` exists, Silero loads from the cache and sets `TORCH_HUB_DISABLE_AUTOFETCH=1` to prevent network access.
+
 ### Manual TTS model fetch
 Download models for offline use:
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,8 @@
 - Consider using `uv pip sync` for reproducibility.
 - Add preset editor and saving UI for `.rvpreset` files.
 
+- Allow configuring custom torch hub cache locations for TTS models.
+
 - Package `run_ui` scripts as a Python entry point for unified CLI launch.
 - Make Silero TTS retry attempts configurable and add exponential backoff.
 - Document troubleshooting for SSL certificate errors during model downloads.

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -163,13 +163,13 @@ class SileroTTS:
             torch_home = Path("models") / "torch_hub"
             torch_home.mkdir(parents=True, exist_ok=True)
             torch.hub.set_dir(str(torch_home))
+            hub_dir = Path(torch.hub.get_dir())
+            cache_dir = hub_dir / "snakers4_silero-models_master"
+            cached_before = cache_dir.exists()
             old_autofetch = os.environ.get("TORCH_HUB_DISABLE_AUTOFETCH")
-            if not auto_download:
+            if cached_before or not auto_download:
                 os.environ["TORCH_HUB_DISABLE_AUTOFETCH"] = "1"
             try:
-                hub_dir = Path(torch.hub.get_dir())
-                cache_dir = hub_dir / "snakers4_silero-models_master"
-                cached_before = cache_dir.exists()
                 if not auto_download and not cached_before:
                     raise RuntimeError(
                         "Silero model cache not found. Enable 'Auto-download models' in Settings or prefetch via CLI."

--- a/tests/test_silero_autofetch_env.py
+++ b/tests/test_silero_autofetch_env.py
@@ -26,6 +26,7 @@ def test_env_restored(monkeypatch, tmp_path, original):
         __version__="0.0",
         set_num_threads=lambda *a, **k: None,
         hub=types.SimpleNamespace(
+            set_dir=lambda *a, **k: None,
             get_dir=lambda: str(hub_dir),
             load=lambda *a, **k: (DummyModel(), "ok"),
         ),
@@ -39,10 +40,40 @@ def test_env_restored(monkeypatch, tmp_path, original):
     else:
         monkeypatch.setenv("TORCH_HUB_DISABLE_AUTOFETCH", original)
 
-    SileroTTS._model = None
-    SileroTTS(auto_download=False)._ensure_model()
+    SileroTTS._models = {}
+    SileroTTS(auto_download=False)._ensure_model(auto_download=False)
 
     if original is None:
         assert "TORCH_HUB_DISABLE_AUTOFETCH" not in os.environ
     else:
         assert os.environ["TORCH_HUB_DISABLE_AUTOFETCH"] == original
+
+
+def test_env_set_for_cached_autodownload_true(monkeypatch, tmp_path):
+    hub_dir = tmp_path / "hub"
+    cache_dir = hub_dir / "snakers4_silero-models_master"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def load(*args, **kwargs):
+        assert os.environ.get("TORCH_HUB_DISABLE_AUTOFETCH") == "1"
+        return DummyModel(), "ok"
+
+    torch = types.SimpleNamespace(
+        __version__="0.0",
+        set_num_threads=lambda *a, **k: None,
+        hub=types.SimpleNamespace(
+            set_dir=lambda *a, **k: None,
+            get_dir=lambda: str(hub_dir),
+            load=load,
+        ),
+        device=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
+
+    monkeypatch.delenv("TORCH_HUB_DISABLE_AUTOFETCH", raising=False)
+
+    SileroTTS._models = {}
+    SileroTTS(auto_download=True)._ensure_model(auto_download=True)
+
+    assert "TORCH_HUB_DISABLE_AUTOFETCH" not in os.environ


### PR DESCRIPTION
## Summary
- avoid network calls when Silero model cache exists

## Changes
- disable torch hub autofetch when `models/torch_hub/snakers4_silero-models_master` is present
- document offline Silero cache behaviour
- cover cached and environment restore cases in tests

## Docs
- `README.md`
- `TODO.md`

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run ruff format core/tts_adapters.py tests/test_silero_autofetch_env.py tests/test_silero_cache.py`
- `uv run pytest tests/test_silero_autofetch_env.py tests/test_silero_cache.py -q`

## Risks
- potential mismatches if cache is corrupted or incomplete

## Rollback
- `git revert <commit>`

## Checklist
- [x] tests
- [x] docs
- [x] changelog
- [x] formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2b126111c83249f580ec096c44a23