### PR TITLE
docs: add offline usage instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   launch via `uv run python -m ui.main`, and `tools/freeze_reqs.py`.
 - Clarified dev dependency installation for quality checks.
 - Explain manual Silero model fetch.
+- Describe offline mode with manual Silero fetch and disabled auto-download.
 - Track VibeVoice TTS integration in TODO.
 - Explain `.rvpreset` preset loading and selection.
 - Document structured TTS configuration keys.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Downloads use local cache and show progress bars. If a fetch fails with SSL
 errors, ensure your system certificates are installed or set `SSL_CERT_FILE` to a
 valid bundle.
 
+### Offline use
+Run fully offline by prefetching models and disabling automatic downloads:
+
+```bash
+python tools/fetch_tts_models.py silero --language <code>
+```
+
+Before launching, either set `TORCH_HUB_DISABLE_AUTOFETCH=1` or turn off
+"Auto-download models" in the settings.
+
 ### TTS dependencies
 Missing Python packages are installed automatically into `.venv` for TTS engines:
 

--- a/TODO.md
+++ b/TODO.md
@@ -54,3 +54,4 @@
 - Add screenshots or diagrams to timeline guide.
 - Automate VRAM usage benchmarking for VibeVoice models.
 - Add UI tests for VibeVoice speaker listing and binary warning.
+- Document offline STT model download steps.


### PR DESCRIPTION
## Summary
- document how to run Silero TTS offline

## Changes
- add README section on offline use with manual Silero fetch and disabling auto-download
- update changelog for offline-mode docs
- note offline STT docs in TODO

## Docs
- updated README.md and CHANGELOG.md
- added note to TODO.md

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uvx ruff check .`

## Risks
- users may misconfigure environment variable or overlook model prefetch

## Rollback
- `git revert <commit>`

## Checklist
- ✅ tests
- ✅ docs
- ✅ changelog
- ✅ formatting
- ✅ CI green

------
https://chatgpt.com/codex/tasks/task_b_68c2b3ae74408324ab24fb8a6701ef80