### PR TITLE
feat: load Silero TTS from local cache when model files exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silero engine now checks for `torchaudio` alongside `torch`.
 - Configuration now uses `tts.default_engine` instead of top-level `tts_engine`.
 - Silero TTS now uses the local torch hub cache when available and disables autofetch to avoid network access.
+- Silero TTS now verifies cached `.pt` files and loads directly from the local cache, prompting for manual download when missing.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu1
 ```
 If these packages are missing, the pipeline falls back to BeepTTS with an audible beep.
 
-If `models/torch_hub/snakers4_silero-models_master` exists, Silero loads from the cache and sets `TORCH_HUB_DISABLE_AUTOFETCH=1` to prevent network access.
+If Silero `.pt` files are present in `models/torch_hub/snakers4_silero-models_master/src/silero/model/`, the engine loads directly from that cache (`repo_or_dir=cache_dir`) and sets `TORCH_HUB_DISABLE_AUTOFETCH=1` to avoid GitHub access.
 
 ### Manual TTS model fetch
 Download models for offline use:

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@
 - Add preset editor and saving UI for `.rvpreset` files.
 
 - Allow configuring custom torch hub cache locations for TTS models.
+- Auto-detect required Silero `.pt` files per language instead of hardcoding names.
 
 - Package `run_ui` scripts as a Python entry point for unified CLI launch.
 - Make Silero TTS retry attempts configurable and add exponential backoff.

--- a/tests/test_silero_autofetch_env.py
+++ b/tests/test_silero_autofetch_env.py
@@ -21,6 +21,8 @@ def test_env_restored(monkeypatch, tmp_path, original):
     hub_dir = tmp_path / "hub"
     cache_dir = hub_dir / "snakers4_silero-models_master"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model").mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model/v4_ru.pt").touch()
 
     torch = types.SimpleNamespace(
         __version__="0.0",
@@ -53,6 +55,8 @@ def test_env_set_for_cached_autodownload_true(monkeypatch, tmp_path):
     hub_dir = tmp_path / "hub"
     cache_dir = hub_dir / "snakers4_silero-models_master"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model").mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model/v4_ru.pt").touch()
 
     def load(*args, **kwargs):
         assert os.environ.get("TORCH_HUB_DISABLE_AUTOFETCH") == "1"

--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -46,6 +46,8 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
     def online_load(*args, **kwargs):
         calls["online"] += 1
         cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "src/silero/model").mkdir(parents=True, exist_ok=True)
+        (cache_dir / "src/silero/model/v4_ru.pt").touch()
         return DummyModel(), "hi"
 
     torch.hub.load = online_load
@@ -58,6 +60,7 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
 
     def offline_load(*args, **kwargs):
         calls["offline"] += 1
+        assert kwargs.get("repo_or_dir") == str(cache_dir)
         if not cache_dir.exists():
             raise RuntimeError("missing")
         return DummyModel(), "hi"


### PR DESCRIPTION
## Summary
- avoid unnecessary GitHub requests by loading Silero models from local cache when `.pt` files are present

## Changes
- check torch hub cache for required `.pt` files before model load
- use local `repo_or_dir` path when cache is complete and raise a clear message otherwise
- document Silero cache path and update related tests

## Docs
- `README.md` updated with `.pt` cache requirements
- `TODO.md` note about detecting model files per language

## Changelog
- see `[Unreleased]` in `CHANGELOG.md`

## Test Plan
- `uv run ruff check core/tts_adapters.py tests/test_silero_cache.py tests/test_silero_autofetch_env.py`
- `uv run pytest tests/test_silero_cache.py tests/test_silero_autofetch_env.py -q`

## Risks
- mismatched or missing `.pt` files could still trigger downloads

## Rollback
- Revert the commit via GitHub's **Revert** button

## Checklist
- ✅ tests (if applicable)
- ✅ docs
- ✅ changelog
- ✅ formatting
- ✅ CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2b7527ffc8324b82581bdbebdcdf1