### PR TITLE
feat: allow skipping SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional GPU offload with peak VRAM/time logging.
 - Tests for dialogue parsing, Russian text segmentation, and TTS engine registry with GPU VibeVoice integration test.
 - VibeVoice engine selectable in UI with dynamic speaker listing and missing binary warning.
+- Support for `NO_SSL_VERIFY=1` to disable SSL certificate verification during Silero downloads.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration now uses `tts.default_engine` instead of top-level `tts_engine`.
 - Silero TTS now uses the local torch hub cache when available and disables autofetch to avoid network access.
 - Silero TTS now verifies cached `.pt` files and loads directly from the local cache, prompting for manual download when missing.
+- Silero download errors now reference `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY` for troubleshooting.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.
@@ -73,3 +75,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mention script parser, autosave and offload options in README.
 - Added VibeVoice and timeline guides; expanded README with uv quick start, model fetch commands, and engine toggle examples.
 - Document VibeVoice binary and model installation.
+- Documented troubleshooting with `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY`.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ uv run python tools/fetch_tts_models.py registry --engine coqui_xtts
 ```
 Downloads use local cache and show progress bars. If a fetch fails with SSL
 errors, ensure your system certificates are installed or set `SSL_CERT_FILE` to a
-valid bundle.
+valid bundle. Behind a proxy, configure `HTTPS_PROXY`. As a last resort, set
+`NO_SSL_VERIFY=1` to skip certificate verification.
 
 ### Offline use
 Run fully offline by prefetching models and disabling automatic downloads:

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,7 @@
 - Package `run_ui` scripts as a Python entry point for unified CLI launch.
 - Make Silero TTS retry attempts configurable and add exponential backoff.
 - Document troubleshooting for SSL certificate errors during model downloads.
+- Provide a UI toggle for `NO_SSL_VERIFY` instead of relying on an environment variable.
 - Integrate VibeVoice TTS engine from Microsoft.
   - Verify compatibility with current architecture.
   - Prepare uv-based installation in a dedicated virtual environment.

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -170,6 +170,8 @@ class SileroTTS:
             torch_home.mkdir(parents=True, exist_ok=True)
             torch.hub.set_dir(str(torch_home))
             hub_dir = Path(torch.hub.get_dir())
+            if os.environ.get("NO_SSL_VERIFY") == "1":
+                ssl._create_default_https_context = ssl._create_unverified_context
             cache_dir = hub_dir / "snakers4_silero-models_master"
             pt_name = SILERO_PT_FILES.get(lang)
             model_path = cache_dir / "src" / "silero" / "model" / pt_name if pt_name else None
@@ -199,7 +201,10 @@ class SileroTTS:
                     except (URLError, ssl.SSLError) as e:
                         logging.warning("torch.hub.load failed (%s/%s): %s", attempt, attempts, e)
                         if attempt == attempts:
-                            msg = "Silero download failed: Run `python tools/fetch_tts_models.py --engine silero` or check internet connection."
+                            msg = (
+                                "Silero download failed: Run `python tools/fetch_tts_models.py --engine silero` or check internet connection. "
+                                "Check SSL_CERT_FILE, HTTPS_PROXY, or set NO_SSL_VERIFY=1 to disable SSL verification."
+                            )
                             logging.debug("Silero download failed", exc_info=True)
                             try:
                                 from .pipeline import TTSEngineError  # type: ignore

--- a/tests/test_silero_no_ssl_env.py
+++ b/tests/test_silero_no_ssl_env.py
@@ -1,0 +1,54 @@
+import ssl
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from core.tts_adapters import SileroTTS
+
+
+class DummyModel:
+    def apply_tts(self, *args, **kwargs):
+        return np.zeros(1, dtype=np.float32)
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+@pytest.mark.parametrize("flag", [None, "1"])
+def test_no_ssl_verify(monkeypatch, tmp_path, flag):
+    hub_dir = tmp_path / "hub"
+    cache_dir = hub_dir / "snakers4_silero-models_master"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model").mkdir(parents=True, exist_ok=True)
+    (cache_dir / "src/silero/model/v4_ru.pt").touch()
+
+    torch = types.SimpleNamespace(
+        __version__="0.0",
+        set_num_threads=lambda *a, **k: None,
+        hub=types.SimpleNamespace(
+            set_dir=lambda *a, **k: None,
+            get_dir=lambda: str(hub_dir),
+            load=lambda *a, **k: (DummyModel(), "ok"),
+        ),
+        device=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
+
+    if flag is None:
+        monkeypatch.delenv("NO_SSL_VERIFY", raising=False)
+    else:
+        monkeypatch.setenv("NO_SSL_VERIFY", flag)
+
+    original_ctx = ssl._create_default_https_context
+    monkeypatch.setattr(ssl, "_create_default_https_context", original_ctx, raising=False)
+
+    SileroTTS._models = {}
+    SileroTTS(auto_download=False)._ensure_model(auto_download=False)
+
+    if flag == "1":
+        assert ssl._create_default_https_context == ssl._create_unverified_context
+    else:
+        assert ssl._create_default_https_context is original_ctx


### PR DESCRIPTION
## Summary
- allow skipping SSL verification for Silero downloads via `NO_SSL_VERIFY`
- reference SSL-related env vars in download errors and docs
- add unit test for `NO_SSL_VERIFY` behavior

## Changes
- check `NO_SSL_VERIFY` before `torch.hub.load` and adjust SSL context
- expand Silero download error message with `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY`
- document `NO_SSL_VERIFY` and proxy variables in README
- cover new env flag with unit test

## Docs
- updated README with SSL troubleshooting
- added item to TODO about UI toggle for `NO_SSL_VERIFY`

## Changelog
- `CHANGELOG.md` under `[Unreleased]`

## Test Plan
- `uv run ruff check core tests`
- `uv run pytest tests/test_silero_no_ssl_env.py -q`

## Risks
- disabling SSL verification may expose users to MITM attacks if misused

## Rollback
- revert this PR via GitHub UI

## Checklist
- [x] tests
- [x] docs
- [x] changelog
- [x] formatting
- [x] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2bcdc17cc83249cab8cafcb8b031e