### PR TITLE
docs: clarify offline silero archive and proxy vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added VibeVoice and timeline guides; expanded README with uv quick start, model fetch commands, and engine toggle examples.
 - Document VibeVoice binary and model installation.
 - Documented troubleshooting with `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY`.
+- Explained manual Silero archive placement and proxy variables for corporate networks.

--- a/README.md
+++ b/README.md
@@ -140,8 +140,19 @@ Run fully offline by prefetching models and disabling automatic downloads:
 python tools/fetch_tts_models.py silero --language <code>
 ```
 
+Alternatively, download the Silero repository archive and unpack it into
+`models/torch_hub/snakers4_silero-models_master/` so that
+`src/silero/model/*.pt` resides inside that folder.
+
 Before launching, either set `TORCH_HUB_DISABLE_AUTOFETCH=1` or turn off
 "Auto-download models" in the settings.
+
+In corporate networks configure proxy and SSL variables before fetching:
+
+```bash
+export HTTPS_PROXY=http://proxy:port  # your corporate proxy
+export NO_SSL_VERIFY=1                # optional, skip TLS validation
+```
 
 ### TTS dependencies
 Missing Python packages are installed automatically into `.venv` for TTS engines:

--- a/TODO.md
+++ b/TODO.md
@@ -57,3 +57,4 @@
 - Automate VRAM usage benchmarking for VibeVoice models.
 - Add UI tests for VibeVoice speaker listing and binary warning.
 - Document offline STT model download steps.
+- Provide helper script to unpack Silero archive into torch hub cache.


### PR DESCRIPTION
## Summary
- clarify how to unpack a downloaded Silero archive for offline use
- note HTTPS_PROXY and NO_SSL_VERIFY for corporate networks
- track helper script idea in TODO

## Changes
- expand Offline use section in README
- note manual Silero archive placement & proxy vars in changelog
- add TODO for Silero archive helper script

## Docs
- Updated README Offline use section with manual archive placement and proxy variables
- Added Silero archive helper script idea to TODO

## Changelog
- See `CHANGELOG.md` under [Unreleased] > Docs

## Test Plan
- `uv run ruff check .`
- `uv run pytest -q` *(fails: AttributeError: module 'torch' has no attribute 'cuda')*

## Risks
- none

## Rollback
- Revert commit via `git revert`

## Sync / Touched files / Overlap notice
- Rebased on latest base: yes; Conflicts resolved: none
- Touched files: README.md, CHANGELOG.md, TODO.md
- Overlap notice: none

## Checklist
- [x] tests
- [x] docs
- [x] changelog
- [x] formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c2c073c8308324aa31117a0d969cda