### PR TITLE
docs: add Borealis ASR integration roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented troubleshooting with `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY`.
 - Explained manual Silero archive placement and proxy variables for corporate networks.
 - Added UI guide and described new Settings dialog.
+- Added Borealis ASR integration roadmap.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+## EN
+
+### Borealis ASR integration — 📝 planned
+- Model confirmation
+- Offline deployment (CUDA, transformers with `trust_remote_code=True`)
+- API adapter (`POST /v1/audio/transcriptions`, `POST /v1/audio/chunked`)
+- Generation parameters (`max_new_tokens≈350`, `top_p=0.9`, `top_k=50`, `temperature=0.2`)
+- Provider registration in config
+- Post-processing
+- Quality expectations
+- Realtime and batch support
+- Logging and checkpoint/feature_extractor version pinning
+
+## RU
+
+### Интеграция Borealis ASR — 📝 planned
+- Подтверждение модели
+- Офлайн-размещение (CUDA, transformers с `trust_remote_code=True`)
+- API-адаптер (`POST /v1/audio/transcriptions`, `POST /v1/audio/chunked`)
+- Параметры генерации (`max_new_tokens≈350`, `top_p=0.9`, `top_k=50`, `temperature=0.2`)
+- Регистрация провайдера в конфиге
+- Постпроцессинг
+- Ожидания по качеству
+- Поддержка realtime/batch
+- Логирование и фиксация версий чекпоинта/feature_extractor


### PR DESCRIPTION
## Summary
- introduce bilingual roadmap entry for upcoming Borealis ASR integration

## Changes
- add `ROADMAP.md` with EN/RU sections and planned steps
- log roadmap addition in `CHANGELOG.md`

## Docs
- `ROADMAP.md` — outlines Borealis ASR integration plan

## Changelog
- Added Borealis ASR integration roadmap.

## Test Plan
- `uv run ruff check`
- `uv run pytest -q` *(fails: module 'torch' has no attribute 'cuda')*

## Risks
- none

## Rollback
- revert this commit

## Sync / Touched files / Overlap notice
- `ROADMAP.md`
- `CHANGELOG.md`

## Checklist
- [ ] tests *(torch.cuda missing)*
- [x] docs
- [x] changelog
- [x] formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c45f649a408324b297846d8bf9e57a