### PR TITLE
docs: add quickstart and development plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explained manual Silero archive placement and proxy variables for corporate networks.
 - Added UI guide and described new Settings dialog.
 - Added Borealis ASR integration roadmap.
+- Added quickstart, CLI, configuration, troubleshooting, and development plan guides.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,3 +25,10 @@
 - Ожидания по качеству
 - Поддержка realtime/batch
 - Логирование и фиксация версий чекпоинта/feature_extractor
+
+## Sprints
+
+- Sprint 1 — Packaging & CI hardening — 📝 planned
+- Sprint 2 — TTS pool finalization — 📝 planned
+- Sprint 3 — Borealis ASR — 📝 planned
+- Sprint 4 — LLM connectors & live mode — 📝 planned

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,17 @@
+# CLI
+
+Запустить озвучку одной фразы:
+```bash
+uv run python -m ui.main --say "текст"
+```
+
+Параметры:
+```text
+usage: - [-h] [--say SAY]
+
+Revoice UI
+
+options:
+  -h, --help  show this help message and exit
+  --say SAY   Text to synthesize and exit
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,19 @@
+# Конфигурация
+
+1. Скопируйте `config.example.json` в `config.json`.
+2. Основные ключи:
+   - `llm.family` — семейство локальной LLM.
+   - `llm.model_path` — путь к файлу модели.
+   - `llm.auto_download` — загружать модель автоматически.
+   - `tts.default_engine` — движок TTS по умолчанию.
+   - `tts.<engine>.model` — имя модели TTS.
+   - `tts.<engine>.device` — устройство (`cpu` или `cuda`).
+   - `tts.<engine>.attention_backend` — бэкенд внимания (`sdpa`, `flash` и т.д.).
+   - `tts.<engine>.quantization` — режим квантования.
+   - `tts.<engine>.voices` — доступные пресеты голосов.
+   - `tts.silence_gap_ms` — пауза между фразами (мс).
+   - `tts.autosave_minutes` — автосохранение чекпоинтов.
+   - `tts.force_offload` — выгружать модель и логировать пик VRAM.
+   - `preferences.pin_dependencies` — предлагать фиксировать зависимости.
+   - `use_imageio_ffmpeg` — автоматически установить `imageio-ffmpeg`.
+   - `externals.ffmpeg` — путь к собственному бинарю FFmpeg.

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -1,0 +1,87 @@
+# Development plan
+
+## Executive summary
+- UI with PySide6 and offline-first TTS pipeline is runnable via `uv` scripts.
+- Plugin architecture supports Silero and VibeVoice; config controls engine, device, attention backend and quantization.
+- AI Edit uses local Qwen or VibeVoice API.
+- Documentation covers UI flows, timeline and VibeVoice setup.
+- Main risks: VRAM usage, Russian diction quality, licensing of voices.
+- Quick wins: add pre-commit config, torch guidance for Silero, offline STT instructions.
+
+## Status board
+| Area | Item | Status | Source |
+|---|---|---|---|
+| UI | Main window, editor, mixer | Done | README.md |
+| UI | Timeline NLE guide screenshots | Planned | TODO.md |
+| TTS | Silero and VibeVoice engines | Done | CHANGELOG.md |
+| TTS | VibeVoice integration tasks | In progress | TODO.md |
+| LLM | `llm` config block and AI Edit | Done | README.md |
+| LLM | Tests for editors | Planned | TODO.md |
+| ASR | Borealis integration | Planned | ROADMAP.md |
+| Packaging | `requirements.txt`, `freeze_reqs.py` | Done | CHANGELOG.md |
+| Packaging | pre-commit and one-shot script | Planned | TODO.md |
+| CI | Ruff on core/ui/tests | Done | CHANGELOG.md |
+| CI | VibeVoice GPU test | Planned | TODO.md |
+| Docs | UI and timeline guides | Done | CHANGELOG.md |
+| Docs | Offline STT download guide | Planned | TODO.md |
+
+## Borealis ASR integration
+| Step | Outcome | Effort |
+|---|---|---|
+| Model confirmation | transformers + CUDA model (`trust_remote_code=True`) | M |
+| Offline deployment | local download and GPU setup | L |
+| API adapters | `POST /v1/audio/transcriptions`, `POST /v1/audio/chunked` | M |
+| Generation params | defaults: `max_new_tokens≈350`, `top_p=0.9`, `top_k=50`, `temperature=0.2` | S |
+| Provider registration | config and model registry entry | M |
+| Post-processing | text normalization, VAD, punctuation | M |
+| Quality tests | WER/SER targets, sample audio tests | M |
+| Realtime & batch | streaming and file jobs | L |
+| Version logging | log and pin checkpoint & feature extractor versions | S |
+| Telemetry | structured logs with params and versions | S |
+
+## LLM integrations
+| Provider | Use cases | Config keys | Notes |
+|---|---|---|---|
+| Qwen (local) | AI Edit offline | `llm.family`, `llm.model_path`, `llm.auto_download` | large model, add tests |
+| OpenAI ChatGPT | cloud fallback | to add: `openai.api_key`, model selector | cost and API limits |
+| Yandex | regional alternative | to add: `yandex.api_key` | availability depends on region |
+| Live mode (Llama.cpp/Mistral) | real-time assistant | `live_mode.enabled`, `talk_llama_fast_path` | package binary, measure latency |
+
+## TTS integrations
+### Offline engines
+- Silero: document torch/torchaudio install and manual model fetch.
+- Coqui XTTS-v2, Dia, MARS5, Orpheus: store weights under `models/tts/<engine>` and register.
+
+### Online or hybrid engines
+- VibeVoice: install binary, support model variants (300M/1.5B/Q8), attention backends (`sdpa`, `flash`, `torch`), quantization and VRAM logging, chunking long scripts, `tts.autosave_minutes`, `tts.force_offload`.
+- gTTS: install `gTTS` package, requires internet.
+- Hume, Gemini, OpenAI TTS, Minimax, Chatterbox: implement API adapters and key management.
+
+## Quality and ops
+- Add unit tests for editors, torch fallback and `ensure_package` logic.
+- Run core tests on CPU and optional GPU suite for VibeVoice and Borealis.
+- Keep CI with Ruff/Mypy/Pytest; add pre-commit hooks and one-shot dev script.
+- Use `uv` with pinned `requirements.txt` regenerated via `tools/freeze_reqs.py`.
+
+## Roadmap (8–12 weeks)
+| Sprint | Focus | Deliverables |
+|---|---|---|
+| 1 (weeks 1–2) | Packaging & CI hardening | pre-commit config, `dev_checks.sh`, torch guidance |
+| 2 (weeks 3–4) | TTS pool finalization | VibeVoice quantization & logging, offline STT docs |
+| 3 (weeks 5–6) | Borealis ASR | model to quality tests (steps 1–7 above) |
+| 4 (weeks 7–8) | LLM connectors & live mode | ChatGPT/Yandex adapters, live mode packaging, timeline screenshots |
+
+## Definition of Done
+- `ruff`, `mypy`, `pytest` green.
+- Docs and changelog updated.
+- Models pinned with logged versions.
+- Reproducible install via `requirements.txt` and `uv`.
+
+## Risk register
+| Risk | Mitigation |
+|---|---|
+| High VRAM usage | quantization, `tts.force_offload`, document hardware needs |
+| Russian diction quality | default RU models and human review |
+| Licensing and voice cloning | user warnings and terms of use |
+| Online API instability | provide offline fallbacks and error handling |
+| Reproducibility | log and pin model versions |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,10 @@
 # Руководство пользователя
 
+- [Быстрый старт](quickstart.md)
+- [CLI](cli.md)
+- [Конфигурация](config.md)
+- [Устранение неполадок](troubleshooting.md)
 - [Руководство по интерфейсу](ui-guide.md)
-
+- [Гайд по таймлайну](ui_timeline.md)
+- [Инструкция по VibeVoice](tts_vibevoice.md)
+- [План разработки](development-plan.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,18 @@
+# Быстрый старт
+
+1. Установите Python 3.10–3.12 и [uv](https://docs.astral.sh/uv/).
+2. Установите зависимости:
+   ```bash
+   uv pip install -r requirements.txt
+   ```
+3. Запустите пользовательский интерфейс:
+   ```bash
+   ./run_ui.sh      # Linux/macOS
+   run_ui.bat       # Windows
+   ```
+   Скрипты выполняют `uv run python -m ui.main`.
+4. Для тестовой озвучки используйте CLI:
+   ```bash
+   uv run python -m ui.main --say "Привет"
+   ```
+   Результат сохранится в `output/tts_test.wav`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,18 @@
+# Устранение неполадок
+
+## Silero: отсутствует torch
+Установите `torch` и `torchaudio`:
+```bash
+uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
+```
+Иначе движок заменится на BeepTTS.
+
+## Ошибки SSL или прокси
+Перед загрузкой моделей задайте:
+```bash
+export HTTPS_PROXY=http://proxy:port
+export NO_SSL_VERIFY=1
+```
+
+## Qt: libGL.so.1 not found
+Установите системную библиотеку `libgl1` (или аналог) перед запуском UI.


### PR DESCRIPTION
## Summary
- add baseline user documentation
- record development plan and link from roadmap

## Changes
- add `docs/quickstart.md`, `docs/cli.md`, `docs/config.md`, and `docs/troubleshooting.md`
- add `docs/development-plan.md` with status board and multi-sprint roadmap
- link new docs from `docs/index.md` and update `ROADMAP.md`
- note documentation in changelog

## Docs
- docs/quickstart.md
- docs/cli.md
- docs/config.md
- docs/troubleshooting.md
- docs/development-plan.md
- docs/index.md
- ROADMAP.md

## Changelog
- Added quickstart, CLI, configuration, troubleshooting, and development plan guides.

## Test Plan
- `uv run ruff check docs`
- `uv run mypy .` *(fails: Source file found twice)*
- `uv run pytest -q` *(fails: module 'torch' has no attribute 'cuda')*

## Risks
- None

## Rollback
- Revert this commit.

## Checklist
- [ ] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c925f9b8088324bbcc4b1df8afa6d0