### PR TITLE
Add regression test for UI config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests for dialogue parsing, Russian text segmentation, and TTS engine registry with GPU VibeVoice integration test.
 - VibeVoice engine selectable in UI with dynamic speaker listing and missing binary warning.
 - Support for `NO_SSL_VERIFY=1` to disable SSL certificate verification during Silero downloads.
+- Regression test covering UI config defaults when `config.json` is absent.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.
@@ -64,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sorted standard library imports in `tests/test_edited_text.py`.
 - CI now sets up a uv virtual environment before installing dependencies.
 - Added retry loop for Silero TTS model download to handle transient network errors.
+- UI config loader now returns the complete default tuple (including preset) when `config.json` is missing.
 
 ### Docs
 - Documented installation with `uv pip`, lazy dependency/model downloads,

--- a/tests/test_load_config_defaults.py
+++ b/tests/test_load_config_defaults.py
@@ -1,0 +1,35 @@
+"""Tests for the UI configuration loader defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ui import config as ui_config
+
+
+def test_load_config_returns_expected_defaults(tmp_path, monkeypatch):
+    """Ensure defaults are returned when the config file is missing."""
+    monkeypatch.setattr(ui_config, "BASE_DIR", Path(tmp_path))
+    monkeypatch.setattr(ui_config, "CONFIG_FILE", Path(tmp_path) / "config.json")
+    monkeypatch.setattr(ui_config, "KEY_FILE", Path(tmp_path) / "config.key")
+
+    defaults = ui_config.load_config()
+
+    expected_output_dir = str((Path(tmp_path) / "output").resolve())
+    expected_defaults = (
+        "",
+        "",
+        False,
+        True,
+        expected_output_dir,
+        "ru",
+        "None",
+        "base",
+        100,
+        350,
+        False,
+        False,
+    )
+
+    assert len(defaults) == 12
+    assert defaults == expected_defaults

--- a/ui/config.py
+++ b/ui/config.py
@@ -45,7 +45,7 @@ def load_config() -> tuple[
     """Load API keys and user preferences from the config file."""
     default_out = str((BASE_DIR / "output").resolve())
     if not CONFIG_FILE.exists():
-        return "", "", False, True, default_out, "ru", "base", 100, 350, False, False
+        return "", "", False, True, default_out, "ru", "None", "base", 100, 350, False, False
     data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
     cipher = _get_cipher()
     yandex_enc = data.get("yandex_key", "")


### PR DESCRIPTION
## Summary
- ensure the UI config loader returns the complete default tuple when config.json is absent
- add a regression test that patches the config location and checks the default values

## Changes
- adjust `ui/config.py` so missing configuration files still provide the preset default
- add `tests/test_load_config_defaults.py` to cover the missing-config path and assert all defaults
- document the change and regression test in the changelog

## Docs
- N/A

## Changelog
- Updated `[Unreleased]` → Added: regression test for UI config defaults
- Updated `[Unreleased]` → Fixed: default tuple now includes the preset when config.json is missing

## Test Plan
- CLI: `pytest tests/test_load_config_defaults.py`

## Risks
- Low: only affects configuration defaults and adds coverage.

## Rollback
- Revert this PR.

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c936fb5b88832487dbde0d0102fe29