### PR TITLE
Add progress callback support to model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ensure_tts_dependencies` calls with direct `ensure_package` usage and lazy heavy imports.
 - Advanced TTS options moved to a dedicated Settings dialog and main UI simplified.
 - Model loading now routes through the new `ensure_model` helper.
+- Model downloads now support optional progress callbacks and debug-level logging updates.
 - Trim default `project.dependencies` to essential packages only.
 - Rename project package to `revoice`.
 - CI installs dependencies with `uv pip install -r requirements.txt` and runs Ruff on `core`, `ui`, and `tests`.


### PR DESCRIPTION
## Summary
- add an optional progress callback to `download_model`
- fall back to debug logging for progress updates when no callback is supplied

## Changes
- extend `core/model_manager.download_model` with a kw-only `progress_callback`
- replace stdout progress printing with callback invocation or debug logging
- refresh the changelog entry to mention the new progress reporting support

## Docs
- n/a

## Changelog
- `CHANGELOG.md`

## Test Plan
- `ruff check core/model_manager.py`
- `pytest` *(fails: AttributeError: module 'torch' has no attribute 'cuda' in tests/test_vibevoice_integration.py)*

## Risks
- Potential regressions in download progress reporting if callers rely on stdout prints

## Rollback
- Revert this PR

## Checklist
- [x] Tests updated or are not required
- [ ] Docs updated or are not required
- [x] Changelog updated or not required
- [x] Formatting checks ran
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c93b006d54832494f2a250542b3acd