### PR TITLE
Add STT model fetch helper and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `tools/fetch_stt_models.py` script with Windows wrapper for prefetching Whisper models.
 - Whisper `base` speech-to-text model registered alongside existing downloads and documented default configuration.
 - VibeEditor for text editing via VibeVoice API.
 - AI Edit dialog can invoke Qwen or VibeVoice editors.
@@ -70,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI config loader now returns the complete default tuple (including preset) when `config.json` is missing.
 
 ### Docs
+- Documented manual STT model download workflow in README and quickstart.
 - Documented UI `config.json` keys, defaults, and storage behaviour.
 - Documented installation with `uv pip`, lazy dependency/model downloads,
   launch via `uv run python -m ui.main`, and `tools/freeze_reqs.py`.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ errors, ensure your system certificates are installed or set `SSL_CERT_FILE` to 
 valid bundle. Behind a proxy, configure `HTTPS_PROXY`. As a last resort, set
 `NO_SSL_VERIFY=1` to skip certificate verification.
 
+### Manual STT model fetch
+Whisper STT weights are stored under `models/stt/<name>`. Prefetch them with:
+```bash
+uv run python tools/fetch_stt_models.py base small medium
+```
+On Windows use the batch helper:
+```bat
+tools\fetch_stt_models.bat base small medium
+```
+Available names follow the registry (`base`, `small`, `medium`, `large-v3`, ...).
+The script reuses the shared Hugging Face cache configured via `HF_HOME`.
+
 ### Offline use
 Run fully offline by prefetching models and disabling automatic downloads:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,3 +16,8 @@
    uv run python -m ui.main --say "Привет"
    ```
    Результат сохранится в `output/tts_test.wav`.
+5. (Опционально) заранее скачайте модели распознавания речи:
+   ```bash
+   uv run python tools/fetch_stt_models.py base small
+   ```
+   На Windows воспользуйтесь `tools\fetch_stt_models.bat base small`.

--- a/tests/test_fetch_stt_models.py
+++ b/tests/test_fetch_stt_models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import fetch_stt_models
+
+
+def test_fetch_stt_models_invokes_ensure_model(monkeypatch, tmp_path):
+    from core import model_service
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(model_service, "_MODEL_REGISTRY", {
+        "stt": {
+            "base": {
+                "files": ["model.bin"],
+                "optional_files": [],
+                "base_urls": ["https://example.com/"],
+            }
+        }
+    })
+    monkeypatch.setattr(model_service, "_MODEL_PATH_CACHE", {})
+    monkeypatch.setattr(model_service, "_CONFIG_CACHE", {})
+
+    calls: list[tuple[str, str, Path]] = []
+
+    def fake_ensure_model(kind: str, file_name: str, dest_dir: Path, url: str, sha256=None):
+        dest = Path(dest_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        target = dest / file_name
+        target.write_text("dummy")
+        calls.append((kind, file_name, dest))
+        return target
+
+    monkeypatch.setattr(model_service, "ensure_model", fake_ensure_model)
+
+    assert fetch_stt_models.fetch_models(["base"]) is True
+    assert calls
+    assert any(path.as_posix().endswith("models/stt/base") for *_rest, path in calls)
+

--- a/tools/fetch_stt_models.bat
+++ b/tools/fetch_stt_models.bat
@@ -1,0 +1,10 @@
+@echo off
+chcp 65001 > nul
+cd /d %~dp0\..
+set HF_HOME=%CD%\hf_cache
+set HUGGINGFACE_HUB_CACHE=%HF_HOME%
+set TRANSFORMERS_CACHE=%HF_HOME%
+echo === Downloading STT models to models\stt ===
+uv run python tools\fetch_stt_models.py %*
+echo Done.
+pause

--- a/tools/fetch_stt_models.py
+++ b/tools/fetch_stt_models.py
@@ -1,0 +1,55 @@
+"""Prefetch STT models for offline use."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from core.model_manager import DownloadError, list_models  # noqa: E402,I001
+from core.model_service import get_model_path  # noqa: E402,I001
+
+
+def fetch_models(models: Iterable[str]) -> bool:
+    """Download the provided STT models."""
+
+    ok = True
+    for name in models:
+        try:
+            path = get_model_path(name, "stt", auto_download=True)
+        except FileNotFoundError as exc:
+            logging.error("%s: not found in registry (%s)", name, exc)
+            ok = False
+        except DownloadError as exc:  # pragma: no cover - network errors
+            logging.error("%s: download failed: %s", name, exc)
+            ok = False
+        else:
+            logging.info("%s: ready at %s", name, path)
+    return ok
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch STT models")
+    available = sorted(list_models("stt"))
+    parser.add_argument(
+        "model",
+        nargs="+",
+        choices=available if available else None,
+        help="Model names to prefetch (e.g. base, small, medium, large-v3)",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    if not fetch_models(args.model):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+


### PR DESCRIPTION
## Summary
- add a CLI helper to prefetch Whisper STT models via `core.model_service`
- provide a Windows batch wrapper and unit test coverage for the fetch helper

## Changes
- add `tools/fetch_stt_models.py` with CLI argument parsing and logging
- add a Windows batch script and pytest covering the ensure_model interaction
- document the workflow in README and quickstart and extend the changelog

## Docs
- README.md
- docs/quickstart.md

## Changelog
- Updated [Unreleased] > Added with the new STT fetch helper entry

## Test Plan
- `uv run pytest tests/test_fetch_stt_models.py`

## Risks
- Low: relies on existing model service logic for downloads

## Rollback
- Revert the commit `Add STT model fetch helper and documentation`

## Checklist
- [x] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c94a9b9bc883248fbeed9c436c2661