### PR TITLE
Update Silero download hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silero TTS now uses the local torch hub cache when available and disables autofetch to avoid network access.
 - Silero TTS now verifies cached `.pt` files and loads directly from the local cache, prompting for manual download when missing.
 - Silero download errors now reference `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY` for troubleshooting.
+- Silero download failure hint now points to `python tools/fetch_tts_models.py silero --language <code>`.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -202,7 +202,7 @@ class SileroTTS:
                         logging.warning("torch.hub.load failed (%s/%s): %s", attempt, attempts, e)
                         if attempt == attempts:
                             msg = (
-                                "Silero download failed: Run `python tools/fetch_tts_models.py --engine silero` or check internet connection. "
+                                "Silero download failed: Run `python tools/fetch_tts_models.py silero --language <code>` or check internet connection. "
                                 "Check SSL_CERT_FILE, HTTPS_PROXY, or set NO_SSL_VERIFY=1 to disable SSL verification."
                             )
                             logging.debug("Silero download failed", exc_info=True)


### PR DESCRIPTION
## Summary
- refresh the Silero download failure guidance to mention the updated language flag for manual model fetches

## Changes
- update the Silero torch hub retry message to recommend `python tools/fetch_tts_models.py silero --language <code>` while keeping SSL environment hints
- document the revised troubleshooting hint in the `[Unreleased]` changelog section

## Docs
- n/a

## Changelog
- `[Unreleased]` → `Changed`

## Test Plan
- run `python -m compileall core/tts_adapters.py` → command completes without errors

## Risks
- low: log message update only

## Rollback
- revert this commit

## Checklist
- [x] Tests
- [ ] Docs updated
- [x] Changelog updated
- [x] Formatting checked
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c95fc248e48324872619c732a1fe73