### PR TITLE
Ensure Silero SSL context is restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI now sets up a uv virtual environment before installing dependencies.
 - `ui.config.load_config` now always returns preset and Whisper defaults even without `config.json`.
 - UI config loader now returns the complete default tuple (including preset) when `config.json` is missing.
+- Restored the default SSL context after Silero downloads when `NO_SSL_VERIFY=1` to avoid global side effects.
 
 ### Docs
 - Documented manual STT model download workflow in README and quickstart.


### PR DESCRIPTION
## Summary
- prevent global SSL overrides when Silero downloads run with NO_SSL_VERIFY
- add regression coverage to confirm the default SSL context is restored after loading

## Changes
- capture and restore ssl._create_default_https_context around torch hub downloads
- extend the Silero NO_SSL tests to assert temporary overrides and restoration
- document the fix in CHANGELOG.md under the unreleased section

## Docs
- N/A

## Changelog
- Updated `[Unreleased]` → `Fixed`: "Restored the default SSL context after Silero downloads when NO_SSL_VERIFY=1 to avoid global side effects."

## Test Plan
- CLI: `pytest tests/test_silero_no_ssl_env.py`
- UI/UX: Not impacted (no UI changes)

## Risks
- Low risk; change is limited to SSL context management during Silero downloads.

## Rollback
- Revert this commit and investigate SSL handling if regressions appear.

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c9613ea3548324874c9a54f15b7cfd