### PR TITLE
Add SSL verification toggle for model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests for dialogue parsing, Russian text segmentation, and TTS engine registry with GPU VibeVoice integration test.
 - VibeVoice engine selectable in UI with dynamic speaker listing and missing binary warning.
 - Support for `NO_SSL_VERIFY=1` to disable SSL certificate verification during Silero downloads.
+- Settings dialog toggle to enable or disable SSL certificate verification for model downloads, persisted in `config.json` and applied during TTS initialization.
 - Regression test covering UI config defaults when `config.json` is absent.
 
 ### Changed
@@ -89,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added VibeVoice and timeline guides; expanded README with uv quick start, model fetch commands, and engine toggle examples.
 - Document VibeVoice binary and model installation.
 - Documented troubleshooting with `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY`.
+- Documented the SSL verification toggle in configuration and troubleshooting guides.
 - Explained manual Silero archive placement and proxy variables for corporate networks.
 - Added UI guide and described new Settings dialog.
 - Documented automatic package installation preference in configuration guide.

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,6 @@
 - Package `run_ui` scripts as a Python entry point for unified CLI launch.
 - Make Silero TTS retry attempts configurable and add exponential backoff.
 - Document troubleshooting for SSL certificate errors during model downloads.
-- Provide a UI toggle for `NO_SSL_VERIFY` instead of relying on an environment variable.
 - Integrate VibeVoice TTS engine from Microsoft.
   - Verify compatibility with current architecture.
   - Prepare uv-based installation in a dedicated virtual environment.

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
   },
   "ffmpeg_version": "",
   "auto_download_models": true,
+  "verify_ssl_downloads": true,
   "whisper_model": "base",
   "llm": {
     "family": "qwen2.5",

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,6 +35,11 @@
   (логическое значение, `false` по умолчанию).
 - `auto_download_models` — разрешить автоматическую загрузку моделей и ресурсов
   (логическое значение, `true` по умолчанию).
+- `verify_ssl_downloads` — проверять SSL-сертификаты при загрузке моделей (`true`
+  по умолчанию; снимите галочку, если трафик проходит через прокси с подменой
+  сертификатов). — `verify_ssl_downloads` — verify SSL certificates when
+  downloading models (`true` by default; uncheck this option when a corporate
+  proxy injects custom certificates).
 - `auto_install_packages` — разрешить автоматически устанавливать недостающие
   Python-пакеты (`true` по умолчанию).
 - `out_dir` — абсолютный путь к папке для сохранения результатов (`output`
@@ -47,6 +52,13 @@
 - `read_numbers` — произносить числа полностью вместо цифр (`false`).
 - `spell_latin` — произносить латиницу посимвольно (`false`).
 
+В диалоге настроек UI появилась опция «Проверять SSL-сертификаты при загрузке
+моделей»: оставляйте её включённой для стандартных сетей, а при проблемах с
+прокси отключайте, чтобы загрузчик создавал небезопасное HTTPS-подключение.
+The UI settings dialog now exposes a "Verify SSL certificates" checkbox—keep it
+enabled for regular networks and disable it only when troubleshooting downloads
+behind a TLS-inspecting proxy.
+
 Пример файла с настройками по умолчанию:
 
 ```json
@@ -55,6 +67,7 @@
   "chatgpt_key": "",
   "allow_beep_fallback": false,
   "auto_download_models": true,
+  "verify_ssl_downloads": true,
   "auto_install_packages": true,
   "out_dir": "/абсолютный/путь/к/output",
   "language": "ru",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,11 +14,16 @@ uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu1
 Иначе движок заменится на BeepTTS.
 
 ## Ошибки SSL или прокси
-Перед загрузкой моделей задайте:
+Отключите опцию «Проверять SSL-сертификаты при загрузке моделей» в настройках UI
+и повторите попытку. Если используете CLI или предпочтителен ручной запуск,
+можно временно задать переменные окружения:
 ```bash
 export HTTPS_PROXY=http://proxy:port
 export NO_SSL_VERIFY=1
 ```
+Disable the "Verify SSL certificates" checkbox in the Settings dialog when a
+corporate proxy replaces certificates; for CLI workflows fall back to the
+environment variables above.
 
 ## Qt: libGL.so.1 not found
 Установите системную библиотеку `libgl1` (или аналог) перед запуском UI.

--- a/tests/test_load_config_defaults.py
+++ b/tests/test_load_config_defaults.py
@@ -16,20 +16,18 @@ def test_load_config_returns_expected_defaults(tmp_path, monkeypatch):
     defaults = ui_config.load_config()
 
     expected_output_dir = str((Path(tmp_path) / "output").resolve())
-    expected_defaults = (
-        "",
-        "",
-        False,
-        True,
-        expected_output_dir,
-        "ru",
-        "None",
-        "base",
-        100,
-        350,
-        False,
-        False,
-    )
-
-    assert len(defaults) == 12
-    assert defaults == expected_defaults
+    assert len(defaults) == len(ui_config.ConfigValues._fields)
+    assert defaults.yandex_key == ""
+    assert defaults.chatgpt_key == ""
+    assert defaults.allow_beep_fallback is False
+    assert defaults.auto_download_models is True
+    assert defaults.verify_ssl_downloads is True
+    assert defaults.auto_install_packages is True
+    assert defaults.out_dir == expected_output_dir
+    assert defaults.language == "ru"
+    assert defaults.preset == "None"
+    assert defaults.whisper_model == "base"
+    assert defaults.speed_pct == 100
+    assert defaults.min_gap_ms == 350
+    assert defaults.read_numbers is False
+    assert defaults.spell_latin is False

--- a/tests/test_silero_no_ssl_env.py
+++ b/tests/test_silero_no_ssl_env.py
@@ -1,4 +1,5 @@
 import ssl
+import ssl
 import sys
 import types
 from typing import Any
@@ -6,7 +7,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from core.tts_adapters import SileroTTS
+from core.tts_adapters import SileroTTS, set_ssl_verification
 
 
 class DummyModel:
@@ -17,8 +18,15 @@ class DummyModel:
         return self
 
 
-@pytest.mark.parametrize("flag", [None, "1"])
-def test_no_ssl_verify(monkeypatch, tmp_path, flag):
+@pytest.mark.parametrize(
+    "mode, expected_unverified",
+    [
+        ("default", False),
+        ("env_off", True),
+        ("toggle_off", True),
+    ],
+)
+def test_no_ssl_verify(monkeypatch, tmp_path, mode, expected_unverified):
     hub_dir = tmp_path / "hub"
     cache_dir = hub_dir / "snakers4_silero-models_master"
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -44,10 +52,13 @@ def test_no_ssl_verify(monkeypatch, tmp_path, flag):
     monkeypatch.setitem(sys.modules, "torch", torch)
     monkeypatch.setitem(sys.modules, "torchaudio", types.ModuleType("torchaudio"))
 
-    if flag is None:
-        monkeypatch.delenv("NO_SSL_VERIFY", raising=False)
+    set_ssl_verification(True)
+    if mode == "env_off":
+        monkeypatch.setenv("NO_SSL_VERIFY", "1")
     else:
-        monkeypatch.setenv("NO_SSL_VERIFY", flag)
+        monkeypatch.delenv("NO_SSL_VERIFY", raising=False)
+    if mode == "toggle_off":
+        set_ssl_verification(False)
 
     original_ctx = ssl._create_default_https_context
     monkeypatch.setattr(ssl, "_create_default_https_context", original_ctx, raising=False)
@@ -60,7 +71,8 @@ def test_no_ssl_verify(monkeypatch, tmp_path, flag):
 
     assert "value" in context_during_load
     expected_context = (
-        ssl._create_unverified_context if flag == "1" else original_ctx
+        ssl._create_unverified_context if expected_unverified else original_ctx
     )
     assert context_during_load["value"] is expected_context
     assert ssl._create_default_https_context is original_ctx
+    set_ssl_verification(True)

--- a/tests/test_ui_config.py
+++ b/tests/test_ui_config.py
@@ -23,6 +23,7 @@ def test_load_config_applies_string_defaults_for_missing_keys(tmp_path, monkeypa
     config_data = {
         "allow_beep_fallback": True,
         "auto_download_models": False,
+        "verify_ssl_downloads": False,
         "out_dir": "custom/out",
         "language": "en",
         "speed_pct": 110,
@@ -44,6 +45,7 @@ def test_load_config_applies_string_defaults_for_missing_keys(tmp_path, monkeypa
     assert result.language == "en"
     assert result.allow_beep_fallback is True
     assert result.auto_download_models is False
+    assert result.verify_ssl_downloads is False
     assert result.auto_install_packages is config.DEFAULT_CONFIG.auto_install_packages
     assert result.speed_pct == 110
     assert result.min_gap_ms == 250

--- a/ui/main.py
+++ b/ui/main.py
@@ -63,7 +63,7 @@ from core.pipeline import (  # noqa: E402
     revoice_video,
     transcribe_whisper,
 )
-from core.tts_adapters import SILERO_VOICES  # noqa: E402
+from core.tts_adapters import SILERO_VOICES, set_ssl_verification  # noqa: E402
 from core.tts_dependencies import TTS_DEPENDENCIES, ensure_tts_dependencies  # noqa: E402
 
 try:
@@ -190,12 +190,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.chatgpt_key = ""
         self.allow_beep_fallback = False
         self.auto_download_models = True
+        self.verify_ssl_downloads = True
         self.auto_install_packages = True
         (
             self.yandex_key,
             self.chatgpt_key,
             self.allow_beep_fallback,
             self.auto_download_models,
+            self.verify_ssl_downloads,
             self.auto_install_packages,
             self.out_dir,
             self.language,
@@ -206,6 +208,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.read_numbers,
             self.spell_latin,
         ) = load_config()
+        set_ssl_verification(self.verify_ssl_downloads)
         self.presets = load_presets(BASE_DIR / "presets")
         self._on_preset_change(self.preset_name)
 
@@ -418,6 +421,7 @@ class MainWindow(QtWidgets.QMainWindow):
             chatgpt_key=self.chatgpt_key,
             allow_beep_fallback=self.allow_beep_fallback,
             auto_download_models=self.auto_download_models,
+            verify_ssl_downloads=self.verify_ssl_downloads,
             auto_install_packages=self.auto_install_packages,
             out_dir=self.out_dir,
             language=self.language,
@@ -437,6 +441,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.chatgpt_key,
                 self.allow_beep_fallback,
                 self.auto_download_models,
+                self.verify_ssl_downloads,
                 self.auto_install_packages,
                 self.out_dir,
                 self.language,
@@ -453,6 +458,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.chatgpt_key,
                 self.allow_beep_fallback,
                 self.auto_download_models,
+                self.verify_ssl_downloads,
                 self.auto_install_packages,
                 self.out_dir,
                 self.language,
@@ -463,6 +469,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.read_numbers,
                 self.spell_latin,
             )
+            set_ssl_verification(self.verify_ssl_downloads)
             self._refresh_voices(self.cmb_engine.currentText())
 
     def show_help(self):

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -20,6 +20,7 @@ class SettingsDialog(QtWidgets.QDialog):
         chatgpt_key: str = "",
         allow_beep_fallback: bool = False,
         auto_download_models: bool = True,
+        verify_ssl_downloads: bool = True,
         auto_install_packages: bool = True,
         out_dir: str = str(OUTPUT_DIR),
         language: str = "ru",
@@ -96,6 +97,9 @@ class SettingsDialog(QtWidgets.QDialog):
         self.chk_auto = QtWidgets.QCheckBox("Auto-download models")
         self.chk_auto.setChecked(auto_download_models)
         form.addRow(self.chk_auto)
+        self.chk_ssl = QtWidgets.QCheckBox("Проверять SSL-сертификаты при загрузке моделей")
+        self.chk_ssl.setChecked(verify_ssl_downloads)
+        form.addRow(self.chk_ssl)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
@@ -117,6 +121,7 @@ class SettingsDialog(QtWidgets.QDialog):
         bool,
         bool,
         bool,
+        bool,
         str,
         str,
         str,
@@ -132,6 +137,7 @@ class SettingsDialog(QtWidgets.QDialog):
             self.ed_chatgpt.text().strip(),
             self.chk_beep.isChecked(),
             self.chk_auto.isChecked(),
+            self.chk_ssl.isChecked(),
             self._auto_install_packages,
             self.ed_out.text().strip(),
             self.cmb_language.currentText(),


### PR DESCRIPTION
## Summary
- add a UI toggle for verifying SSL certificates during model downloads and persist it in the user config

## Changes
- extend `ui.config` to store `verify_ssl_downloads`, expose it in the settings dialog, and apply it from the main window
- add global helpers in `core.tts_adapters` so Silero downloads respect the SSL preference and default to the saved config
- update unit tests, config example, and troubleshooting docs for the new option

## Docs
- docs/config.md
- docs/troubleshooting.md

## Changelog
- Added a note about the new SSL verification toggle under `[Unreleased]`

## Test Plan
- CLI: `pytest tests/test_ui_config.py tests/test_load_config_defaults.py tests/test_silero_no_ssl_env.py`
- UI/UX: launch the UI, open Settings → confirm the "Проверять SSL-сертификаты при загрузке моделей" checkbox appears and persists between launches

## Risks
- Low: touches configuration plumbing and Silero initialization

## Rollback
- Revert the commit

## Checklist
- [x] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c9651d5afc83249d6fc1a52f09d2f9