### PR TITLE
Add QA runner CLI and reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `NO_SSL_VERIFY=1` to disable SSL certificate verification during Silero downloads.
 - Settings dialog toggle to enable or disable SSL certificate verification for model downloads, persisted in `config.json` and applied during TTS initialization.
 - Regression test covering UI config defaults when `config.json` is absent.
+- `revoice-check` QA runner CLI to execute uv-based installation, Ruff, MyPy, and pytest with aggregated reporting.
 
 ### Changed
 - Install TTS dependencies into .venv using shared pkg_installer.
@@ -96,3 +97,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented automatic package installation preference in configuration guide.
 - Added Borealis ASR integration roadmap.
 - Added quickstart, CLI, configuration, troubleshooting, and development plan guides.
+- Documented the `revoice-check` workflow in README and CLI guide, including report formats and storage options.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,19 @@ uv run python -m ui.main
 - Пропущенные Python-зависимости устанавливаются автоматически в `.venv`,
   а недостающие модели скачиваются в `models/` при первом использовании.
 - Проверки качества:
-  Перед запуском установите dev-зависимости (ruff, mypy, pytest):
-  ```bash
-  uv pip install --extra dev .
-  uv run ruff check .
-  uv run ruff format --check .
-  uv run mypy .
-  uv run pytest -q
-  ```
+  - Быстрый запуск всех проверок и генерация отчёта:
+    ```bash
+    uv run revoice-check --format markdown --output reports/qa_report.md
+    ```
+    Форматы `stdout`, `json` и `markdown` поддерживают сохранение отчёта через `--output`.
+  - При необходимости можно выполнить шаги вручную:
+    ```bash
+    uv pip install --extra dev .
+    uv run ruff check .
+    uv run ruff format --check .
+    uv run mypy .
+    uv run pytest -q
+    ```
 - Обновление списка зависимостей (после ленивой установки):
 ```bash
 uv run python tools/freeze_reqs.py

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,7 @@
 # CLI
 
+## Revoice UI
+
 Запустить озвучку одной фразы:
 ```bash
 uv run python -m ui.main --say "текст"
@@ -14,4 +16,27 @@ Revoice UI
 options:
   -h, --help  show this help message and exit
   --say SAY   Text to synthesize and exit
+```
+
+## revoice-check (QA)
+
+Команда агрегирует установку dev-зависимостей и запуск `ruff`, `mypy`, `pytest`,
+поддерживая вывод в stdout/JSON/Markdown и сохранение отчёта:
+
+```bash
+uv run revoice-check --format markdown --output reports/qa_report.md
+```
+
+Помощь по параметрам:
+
+```text
+usage: revoice-check [-h] [--format {stdout,json,markdown}] [--output OUTPUT]
+
+Run QA checks with uv helpers
+
+options:
+  -h, --help            show this help message and exit
+  --format {stdout,json,markdown}
+                        Output format for the report
+  --output OUTPUT       Optional file path to store the generated report
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff>=0.5", "mypy>=1.10"]
 
+[project.scripts]
+revoice-check = "tools.qa_runner:main"
+
 [tool.uv]
 # При желании можно зафиксировать индекс/кэши
 

--- a/tests/test_qa_runner.py
+++ b/tests/test_qa_runner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tools import qa_runner
+
+
+@pytest.fixture(autouse=True)
+def _patch_ensure_uv(monkeypatch):
+    monkeypatch.setattr(qa_runner, "ensure_uv", lambda: None)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_run_checks_success(monkeypatch, tmp_path):
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(args, capture_output: bool, text: bool):
+        calls.append(tuple(args))
+        index = len(calls)
+        return _completed(0, stdout=f"ok-{index}")
+
+    monkeypatch.setattr(qa_runner.subprocess, "run", fake_run)
+    output_path = tmp_path / "reports" / "qa.json"
+    buffer = io.StringIO()
+
+    summary = qa_runner.run_checks(report_format="json", output_path=output_path, stream=buffer)
+
+    assert summary.exit_code == 0
+    assert all(result.succeeded for result in summary.results)
+    assert len(calls) == len(qa_runner.COMMANDS)
+
+    payload = json.loads(summary.report)
+    assert payload["status"] == "success"
+    assert payload["exit_code"] == 0
+    assert [tuple(entry["command"]) for entry in payload["results"]] == calls
+
+    assert output_path.read_text(encoding="utf-8") == summary.report
+    assert buffer.getvalue() == summary.report
+
+
+def test_run_checks_failure(monkeypatch):
+    codes = iter([0, 1, 0, 0, 0])
+    outputs = {1: "lint error"}
+    seen = []
+
+    def fake_run(args, capture_output: bool, text: bool):
+        code = next(codes)
+        seen.append(tuple(args))
+        return _completed(code, stdout=f"stdout-{code}", stderr=outputs.get(code, ""))
+
+    monkeypatch.setattr(qa_runner.subprocess, "run", fake_run)
+    buffer = io.StringIO()
+
+    summary = qa_runner.run_checks(report_format="stdout", stream=buffer)
+
+    assert summary.exit_code == 1
+    assert any(not result.succeeded for result in summary.results)
+    assert "FAILED" in summary.report
+    assert "Final status: FAILURE" in summary.report
+    assert seen == [tuple(spec.args) for spec in qa_runner.COMMANDS]
+
+
+def test_main_passes_arguments(monkeypatch, tmp_path):
+    recorded: dict[str, object] = {}
+
+    def fake_run_checks(*, report_format: str, output_path: Path | None, stream=None):
+        recorded["format"] = report_format
+        recorded["output"] = output_path
+        return qa_runner.RunSummary(results=[], report="", exit_code=0)
+
+    monkeypatch.setattr(qa_runner, "run_checks", fake_run_checks)
+
+    target = tmp_path / "qa.md"
+    exit_code = qa_runner.main(["--format", "markdown", "--output", str(target)])
+
+    assert exit_code == 0
+    assert recorded == {"format": "markdown", "output": target}

--- a/tools/qa_runner.py
+++ b/tools/qa_runner.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence, TextIO
+
+from core.pkg_installer import ensure_uv
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    args: Sequence[str]
+
+
+@dataclass
+class CommandResult:
+    name: str
+    args: Sequence[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+@dataclass
+class RunSummary:
+    results: list[CommandResult]
+    report: str
+    exit_code: int
+
+    @property
+    def status(self) -> str:
+        return "success" if self.exit_code == 0 else "failure"
+
+
+COMMANDS: tuple[CommandSpec, ...] = (
+    CommandSpec("Install dev dependencies", ("uv", "pip", "install", "--extra", "dev", ".")),
+    CommandSpec("Ruff lint", ("uv", "run", "ruff", "check", ".")),
+    CommandSpec("Ruff format check", ("uv", "run", "ruff", "format", "--check", ".")),
+    CommandSpec("Mypy type check", ("uv", "run", "mypy", ".")),
+    CommandSpec("Pytest", ("uv", "run", "pytest", "-q")),
+)
+
+
+def _run_command(spec: CommandSpec) -> CommandResult:
+    completed = subprocess.run(spec.args, capture_output=True, text=True)
+    return CommandResult(
+        name=spec.name,
+        args=tuple(spec.args),
+        returncode=completed.returncode,
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+    )
+
+
+def _execute_commands() -> list[CommandResult]:
+    ensure_uv()
+    return [_run_command(spec) for spec in COMMANDS]
+
+
+def _status_from_results(results: Iterable[CommandResult]) -> tuple[str, int]:
+    exit_code = 0
+    for result in results:
+        if result.returncode != 0:
+            exit_code = 1
+    status = "success" if exit_code == 0 else "failure"
+    return status, exit_code
+
+
+def _format_command(args: Sequence[str]) -> str:
+    return " ".join(args)
+
+
+def _render_stdout(results: list[CommandResult]) -> str:
+    status, exit_code = _status_from_results(results)
+    lines = ["QA checks summary:", ""]
+    for result in results:
+        state = "PASSED" if result.succeeded else "FAILED"
+        lines.append(
+            f"- {result.name}: {state} (exit code {result.returncode})\n  Command: {_format_command(result.args)}"
+        )
+        if result.stdout:
+            lines.append("  stdout:")
+            lines.append("    " + "\n    ".join(result.stdout.rstrip().splitlines()))
+        if result.stderr:
+            lines.append("  stderr:")
+            lines.append("    " + "\n    ".join(result.stderr.rstrip().splitlines()))
+        lines.append("")
+    lines.append(f"Final status: {status.upper()}")
+    lines.append(f"Exit code: {exit_code}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_json(results: list[CommandResult]) -> str:
+    status, exit_code = _status_from_results(results)
+    payload = {
+        "status": status,
+        "exit_code": exit_code,
+        "results": [
+            {
+                "name": result.name,
+                "command": list(result.args),
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+            for result in results
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def _escape_markdown(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def _render_markdown(results: list[CommandResult]) -> str:
+    status, exit_code = _status_from_results(results)
+    lines = ["# QA Report", "", "| Step | Command | Status | Exit code |", "| --- | --- | --- | --- |"]
+    for index, result in enumerate(results, start=1):
+        state = "✅ Passed" if result.succeeded else "❌ Failed"
+        command = _escape_markdown(_format_command(result.args))
+        lines.append(f"| {index} | `{command}` | {state} | {result.returncode} |")
+    lines.extend(["", f"**Final status:** {status.upper()}", f"**Exit code:** {exit_code}"])
+    for index, result in enumerate(results, start=1):
+        lines.extend(["", f"## Step {index}: {result.name}", "", f"**Command:** `{_escape_markdown(_format_command(result.args))}`"])
+        if result.stdout:
+            lines.extend(["", "<details><summary>stdout</summary>", "", "```", result.stdout.rstrip(), "```", "", "</details>"])
+        if result.stderr:
+            lines.extend(["", "<details><summary>stderr</summary>", "", "```", result.stderr.rstrip(), "```", "", "</details>"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_report(results: list[CommandResult], report_format: str) -> str:
+    if report_format == "stdout":
+        return _render_stdout(results)
+    if report_format == "json":
+        return _render_json(results)
+    if report_format == "markdown":
+        return _render_markdown(results)
+    raise ValueError(f"Unsupported report format: {report_format}")
+
+
+def run_checks(
+    report_format: str = "stdout",
+    output_path: Path | None = None,
+    stream: TextIO | None = None,
+) -> RunSummary:
+    if stream is None:
+        stream = sys.stdout
+    results = _execute_commands()
+    report = render_report(results, report_format)
+    _, exit_code = _status_from_results(results)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(report, encoding="utf-8")
+    try:
+        stream.write(report)
+        if not report.endswith("\n"):
+            stream.write("\n")
+    except BrokenPipeError:  # pragma: no cover - stream closed
+        pass
+    return RunSummary(results=results, report=report, exit_code=exit_code)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="revoice-check",
+        description="Run QA checks with uv helpers",
+    )
+    parser.add_argument(
+        "--format",
+        dest="report_format",
+        choices=("stdout", "json", "markdown"),
+        default="stdout",
+        help="Output format for the report",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional file path to store the generated report",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    summary = run_checks(report_format=args.report_format, output_path=args.output)
+    return summary.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary
- Introduce an aggregated QA runner CLI with selectable report formats.

Changes
- Added `tools/qa_runner.py` to orchestrate uv-based installs and QA tools, capturing output and emitting stdout/JSON/Markdown summaries.
- Registered the `revoice-check` entrypoint, refreshed README/CLI docs, and covered success/failure/report generation paths with unit tests.

Docs
- README.md
- docs/cli.md

Changelog
- Added `revoice-check` QA runner CLI and documented its workflow.

Test Plan
- CLI: run `python -m tools.qa_runner --help` → help lists format/output arguments.
- CLI: run `pytest tests/test_qa_runner.py -q` → three tests pass.

Risks
- Low; the new CLI wraps existing QA tooling without affecting the runtime pipeline.

Rollback
- Revert this commit.

Checklist
- [x] Tests
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c99d3a1e988324a65f768e1242cc0b