### PR TITLE
Ensure Silero cached loads use local source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silero TTS now verifies cached `.pt` files and loads directly from the local cache, prompting for manual download when missing.
 - Silero download errors now reference `SSL_CERT_FILE`, `HTTPS_PROXY`, and `NO_SSL_VERIFY` for troubleshooting.
 - Silero download failure hint now points to `python tools/fetch_tts_models.py silero --language <code>`.
+- Silero TTS now marks cached loads as `source="local"` to keep torch hub on the offline path.
 
 ### Removed
 - Removed legacy bootstrap and launcher scripts.

--- a/core/tts_adapters.py
+++ b/core/tts_adapters.py
@@ -247,15 +247,19 @@ class SileroTTS:
                     attempts = 3
                     for attempt in range(1, attempts + 1):
                         try:
-                            repo = str(cache_dir) if cached_before else "snakers4/silero-models"
-                            model, _ = torch.hub.load(
-                                repo_or_dir=repo,
-                                model="silero_tts",
-                                language=lang,
-                                speaker=SILERO_LANG_MODELS.get(lang, "v4_ru"),
-                                trust_repo=True,
-                                force_reload=False,
-                            )
+                            load_kwargs = {
+                                "repo_or_dir": str(cache_dir)
+                                if cached_before
+                                else "snakers4/silero-models",
+                                "model": "silero_tts",
+                                "language": lang,
+                                "speaker": SILERO_LANG_MODELS.get(lang, "v4_ru"),
+                                "trust_repo": True,
+                                "force_reload": False,
+                            }
+                            if cached_before:
+                                load_kwargs["source"] = "local"
+                            model, _ = torch.hub.load(**load_kwargs)
                             break
                         except (URLError, ssl.SSLError) as e:
                             logging.warning("torch.hub.load failed (%s/%s): %s", attempt, attempts, e)

--- a/tests/test_silero_cache.py
+++ b/tests/test_silero_cache.py
@@ -45,6 +45,8 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
 
     def online_load(*args, **kwargs):
         calls["online"] += 1
+        assert kwargs.get("repo_or_dir") == "snakers4/silero-models"
+        assert "source" not in kwargs
         cache_dir.mkdir(parents=True, exist_ok=True)
         (cache_dir / "src/silero/model").mkdir(parents=True, exist_ok=True)
         (cache_dir / "src/silero/model/v4_ru.pt").touch()
@@ -61,6 +63,7 @@ def test_silero_download_and_cache(monkeypatch, tmp_path, caplog):
     def offline_load(*args, **kwargs):
         calls["offline"] += 1
         assert kwargs.get("repo_or_dir") == str(cache_dir)
+        assert kwargs.get("source") == "local"
         if not cache_dir.exists():
             raise RuntimeError("missing")
         return DummyModel(), "hi"


### PR DESCRIPTION
## Summary
- ensure Silero cached loads invoke torch hub with the local source flag
- extend Silero cache tests to assert the correct repo source for cached and uncached flows
- document the behaviour tweak in the changelog

## Changes
- update `SileroTTS._ensure_model` to pass `source="local"` when loading from cache
- expand `tests/test_silero_cache.py` to validate source handling for cached versus remote loads
- record the adjustment in `CHANGELOG.md`

## Docs
- n/a

## Changelog
- Updated `CHANGELOG.md` under `[Unreleased]`

## Test Plan
1. Run `pytest tests/test_silero_cache.py` → succeeds.
2. Run `pytest tests/test_silero_no_ssl_env.py` → succeeds.
3. Run `pytest tests/test_silero_autofetch_env.py` → succeeds.

## Risks
- Low: touches Silero torch hub invocation and its tests.

## Rollback
- Revert this commit.

## Checklist
- [x] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting/Linting
- [x] CI Green (or not run)


------
https://chatgpt.com/codex/tasks/task_b_68ca5d58bcdc83249536a5341c877f83